### PR TITLE
feat: add format detection and migrate to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# data files (produced by scraper, injected at build time)
+data/*.db
+
+# scraper source reference (incorporated into src/)
+scraper/

--- a/docs/superpowers/plans/2026-04-06-responsive-design.md
+++ b/docs/superpowers/plans/2026-04-06-responsive-design.md
@@ -1,0 +1,855 @@
+# Responsive Design Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the entire Pardonned site fully responsive so it looks great on mobile, tablet, and desktop.
+
+**Architecture:** The site already uses Tailwind CSS 3.4. We'll use Tailwind's responsive prefixes (`sm:`, `md:`, `lg:`) to make grids, padding, and typography adapt to screen size. Font sizes defined in `global.css` will get `@media` queries. The header will get a mobile hamburger menu with a simple inline `<script>` (matching the existing pattern used on the search page).
+
+**Tech Stack:** Astro 6, Tailwind CSS 3.4, vanilla JS (inline scripts for mobile nav toggle)
+
+**Breakpoint strategy (Tailwind defaults):**
+- Base (0-639px): Mobile phones
+- `sm:` (640px+): Large phones / small tablets
+- `md:` (768px+): Tablets
+- `lg:` (1024px+): Desktops
+
+---
+
+### Task 1: Fix Viewport Meta Tag
+
+**Files:**
+- Modify: `src/layouts/Layout.astro:45`
+
+- [ ] **Step 1: Update viewport meta tag**
+
+Change line 45 in `src/layouts/Layout.astro` from:
+
+```html
+<meta name="viewport" content="width=device-width" />
+```
+
+to:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Run: `pnpm dev`
+Open the site on a mobile device or Chrome DevTools mobile emulation. Confirm the page no longer zooms out to fit the desktop layout — it should render at device width. Content will still overflow at this point (that's expected — we fix it in subsequent tasks).
+
+- [ ] **Step 3: Commit**
+
+```bash
+but commit -m "fix: add initial-scale=1 to viewport meta tag"
+```
+
+---
+
+### Task 2: Responsive Typography in Global CSS
+
+**Files:**
+- Modify: `src/styles/global.css:29-37` (base h1/h2 sizes)
+- Modify: `src/styles/global.css:74-96` (stat-number sizes)
+- Modify: `src/styles/global.css:325-331` (hero-headline)
+- Modify: `src/styles/global.css:333-337` (hero-subtitle)
+- Modify: `src/styles/global.css:307-315` (source-banner padding)
+
+- [ ] **Step 1: Add responsive base heading sizes**
+
+In `src/styles/global.css`, replace the `h1` and `h2` rules inside `@layer base` (lines 29-37):
+
+```css
+  h1 {
+    font-size: 24px;
+    line-height: 1.2;
+  }
+
+  h2 {
+    font-size: 22px;
+    line-height: 1.3;
+  }
+
+  @media (min-width: 768px) {
+    h1 {
+      font-size: 36px;
+    }
+    h2 {
+      font-size: 28px;
+    }
+  }
+```
+
+- [ ] **Step 2: Add responsive hero-headline**
+
+In `src/styles/global.css`, replace the `.hero-headline` rule (lines 325-331):
+
+```css
+  .hero-headline {
+    font-family: "DM Serif Display", Georgia, serif;
+    font-size: 32px;
+    line-height: 1.15;
+    color: #1a1918;
+    letter-spacing: -0.02em;
+  }
+
+  @media (min-width: 768px) {
+    .hero-headline {
+      font-size: 52px;
+      line-height: 1.1;
+    }
+  }
+```
+
+- [ ] **Step 3: Add responsive hero-subtitle**
+
+Replace `.hero-subtitle` (lines 333-337):
+
+```css
+  .hero-subtitle {
+    font-size: 16px;
+    line-height: 1.6;
+    color: #6a6860;
+  }
+
+  @media (min-width: 768px) {
+    .hero-subtitle {
+      font-size: 18px;
+    }
+  }
+```
+
+- [ ] **Step 4: Add responsive stat-number**
+
+Replace `.stat-number` (lines 86-90):
+
+```css
+  .stat-number {
+    font-family: "DM Serif Display", Georgia, serif;
+    font-size: 24px;
+    line-height: 1.1;
+  }
+
+  @media (min-width: 768px) {
+    .stat-number {
+      font-size: 36px;
+    }
+  }
+```
+
+- [ ] **Step 5: Add responsive stat-card padding**
+
+Replace `.stat-card` (lines 74-79):
+
+```css
+  .stat-card {
+    background: #ffffff;
+    border: 1px solid #e8e6e0;
+    border-radius: 8px;
+    padding: 16px 12px;
+  }
+
+  @media (min-width: 768px) {
+    .stat-card {
+      padding: 24px 16px;
+    }
+  }
+```
+
+- [ ] **Step 6: Add responsive source-banner padding**
+
+Replace `.source-banner` (lines 307-315):
+
+```css
+  .source-banner {
+    background: rgba(194, 59, 34, 0.04);
+    border: 1px solid rgba(194, 59, 34, 0.12);
+    border-radius: 8px;
+    padding: 16px 20px;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  @media (min-width: 768px) {
+    .source-banner {
+      padding: 24px 32px;
+      gap: 16px;
+    }
+  }
+```
+
+- [ ] **Step 7: Verify typography in browser**
+
+Run: `pnpm dev`
+Check at mobile (375px) and desktop (1280px) widths. Confirm:
+- Hero headline is ~32px on mobile, 52px on desktop
+- h1/h2 scale appropriately
+- Stat numbers don't overflow their cards on mobile
+
+- [ ] **Step 8: Commit**
+
+```bash
+but commit -m "feat: add responsive typography and component sizing"
+```
+
+---
+
+### Task 3: Responsive Header with Mobile Navigation
+
+**Files:**
+- Modify: `src/components/Header.astro` (entire file)
+- Modify: `src/styles/global.css` (add mobile nav styles at end of components layer)
+
+- [ ] **Step 1: Add mobile nav styles to global.css**
+
+Add the following at the end of the `@layer components` block (before the closing `}` on line 377):
+
+```css
+  .mobile-nav-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #4a4840;
+  }
+
+  .mobile-nav {
+    display: none;
+    border-bottom: 1px solid #e8e6e0;
+    padding: 0 20px 16px;
+  }
+
+  .mobile-nav.is-open {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  @media (min-width: 768px) {
+    .mobile-nav-toggle {
+      display: none;
+    }
+    .mobile-nav {
+      display: none !important;
+    }
+  }
+```
+
+- [ ] **Step 2: Update Header.astro with hamburger menu**
+
+Replace the entire content of `src/components/Header.astro` with:
+
+```astro
+---
+import { siteConfig } from '../config/site';
+import { mainNavigation, isActiveNavItem } from '../config/navigation';
+
+interface Props {
+  currentPath?: string;
+}
+
+const { currentPath = "/" } = Astro.props;
+---
+
+<header class="border-b border-border-DEFAULT">
+  <div class="max-w-home mx-auto px-5 md:px-10 py-4 flex justify-between items-center">
+    <!-- Logo / Wordmark -->
+    <a href="/" class="flex items-baseline gap-3 no-underline hover:opacity-80 transition-opacity">
+      <span class="wordmark">
+        Pardonn<span class="wordmark-accent">e</span>d
+      </span>
+      <span class="tracker-label hidden sm:inline">{siteConfig.tagline}</span>
+    </a>
+
+    <!-- Desktop Navigation -->
+    <nav class="hidden md:flex gap-8">
+      {mainNavigation.map((item) => {
+        const isActive = isActiveNavItem(item.href, currentPath);
+        return (
+          <a
+            href={item.href}
+            class:list={[
+              "text-nav transition-colors pb-0.5",
+              isActive
+                ? "text-text-primary font-medium border-b border-accent"
+                : "text-text-muted hover:text-text-primary"
+            ]}
+          >
+            {item.label}
+          </a>
+        );
+      })}
+    </nav>
+
+    <!-- Mobile Hamburger Button -->
+    <button
+      class="mobile-nav-toggle md:hidden"
+      aria-label="Toggle navigation"
+      aria-expanded="false"
+      id="mobile-nav-toggle"
+    >
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+        <line x1="3" y1="18" x2="21" y2="18" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Mobile Navigation Drawer -->
+  <nav class="mobile-nav md:hidden" id="mobile-nav">
+    {mainNavigation.map((item) => {
+      const isActive = isActiveNavItem(item.href, currentPath);
+      return (
+        <a
+          href={item.href}
+          class:list={[
+            "text-nav transition-colors py-2",
+            isActive
+              ? "text-text-primary font-medium"
+              : "text-text-muted hover:text-text-primary"
+          ]}
+        >
+          {item.label}
+        </a>
+      );
+    })}
+  </nav>
+</header>
+
+<script is:inline>
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('mobile-nav-toggle');
+    const nav = document.getElementById('mobile-nav');
+    if (!toggle || !nav) return;
+
+    toggle.addEventListener('click', () => {
+      const isOpen = nav.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', String(isOpen));
+    });
+  });
+</script>
+```
+
+- [ ] **Step 3: Verify mobile header**
+
+Run: `pnpm dev`
+At mobile width (<768px):
+- Hamburger icon is visible, desktop nav links are hidden
+- Tapping hamburger opens the mobile nav drawer with links
+- Tagline is hidden on very small screens (<640px)
+At desktop width (>=768px):
+- Desktop nav links visible, hamburger hidden
+
+- [ ] **Step 4: Commit**
+
+```bash
+but commit -m "feat: add responsive header with mobile hamburger nav"
+```
+
+---
+
+### Task 4: Responsive StatGrid
+
+**Files:**
+- Modify: `src/components/StatGrid.astro:39`
+
+- [ ] **Step 1: Make stat grid responsive**
+
+In `src/components/StatGrid.astro`, change line 39 from:
+
+```html
+<div class="grid grid-cols-4 gap-stat-grid">
+```
+
+to:
+
+```html
+<div class="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-stat-grid">
+```
+
+- [ ] **Step 2: Verify stat grid**
+
+Run: `pnpm dev`
+At mobile: 2x2 grid of stat cards. At desktop: 4-column row.
+
+- [ ] **Step 3: Commit**
+
+```bash
+but commit -m "feat: make stat grid 2-col on mobile, 4-col on desktop"
+```
+
+---
+
+### Task 5: Responsive CategoryGrid
+
+**Files:**
+- Modify: `src/components/CategoryGrid.astro:21-24`
+
+- [ ] **Step 1: Make category grid responsive**
+
+In `src/components/CategoryGrid.astro`, replace lines 21-24:
+
+```astro
+const gridClasses = columns === 2 ? 'grid-cols-2' : 'grid-cols-3';
+---
+
+<div class:list={['grid gap-grid', gridClasses]}>
+```
+
+with:
+
+```astro
+const gridClasses = columns === 2
+  ? 'grid-cols-1 sm:grid-cols-2'
+  : 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3';
+---
+
+<div class:list={['grid gap-3 sm:gap-grid', gridClasses]}>
+```
+
+- [ ] **Step 2: Verify category grid**
+
+Run: `pnpm dev`
+At mobile: single column stack. At sm (640px+): 2 columns. At md (768px+): 3 columns (if `columns=3`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+but commit -m "feat: make category grid responsive across breakpoints"
+```
+
+---
+
+### Task 6: Responsive Home Page Layout
+
+**Files:**
+- Modify: `src/pages/index.astro:98-148`
+
+- [ ] **Step 1: Update home page padding and spacing**
+
+In `src/pages/index.astro`, make the following replacements:
+
+**Line 98** — Hero section:
+```html
+<section class="py-20 px-10 max-w-home mx-auto text-center">
+```
+becomes:
+```html
+<section class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center">
+```
+
+**Line 108** — Gradient divider wrapper:
+```html
+<div class="max-w-home mx-auto px-10">
+```
+becomes:
+```html
+<div class="max-w-home mx-auto px-5 md:px-10">
+```
+
+**Line 113** — Categories section:
+```html
+<section class="py-section px-10 max-w-home mx-auto">
+```
+becomes:
+```html
+<section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto">
+```
+
+**Line 125** — Flat divider wrapper:
+```html
+<div class="max-w-home mx-auto px-10">
+```
+becomes:
+```html
+<div class="max-w-home mx-auto px-5 md:px-10">
+```
+
+**Line 130** — Timeline section:
+```html
+<section class="py-section px-10 max-w-home mx-auto">
+```
+becomes:
+```html
+<section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto">
+```
+
+**Line 145** — Source banner section:
+```html
+<section class="max-w-source mx-auto px-8 mb-10">
+```
+becomes:
+```html
+<section class="max-w-source mx-auto px-5 md:px-8 mb-10">
+```
+
+- [ ] **Step 2: Verify home page on mobile**
+
+Run: `pnpm dev`
+At 375px width: comfortable padding (20px sides), no horizontal overflow.
+At desktop: original 40px padding preserved.
+
+- [ ] **Step 3: Commit**
+
+```bash
+but commit -m "feat: responsive padding and spacing on home page"
+```
+
+---
+
+### Task 7: Responsive Search Page Layout
+
+**Files:**
+- Modify: `src/pages/search.astro:73-117`
+
+- [ ] **Step 1: Update search page container padding**
+
+In `src/pages/search.astro`, change line 73:
+
+```html
+<div class="max-w-search mx-auto px-10 py-section">
+```
+
+to:
+
+```html
+<div class="max-w-search mx-auto px-5 md:px-10 py-10 md:py-section">
+```
+
+- [ ] **Step 2: Make search filter input full-width on mobile**
+
+In `src/pages/search.astro`, change line 81:
+
+```html
+<div class="flex flex-wrap gap-3 items-center">
+```
+
+to:
+
+```html
+<div class="flex flex-col sm:flex-row flex-wrap gap-3 items-stretch sm:items-center">
+```
+
+And change line 87 — the search input:
+
+```html
+class="filter-input flex-1 min-w-[200px]"
+```
+
+to:
+
+```html
+class="filter-input flex-1 w-full sm:w-auto sm:min-w-[200px]"
+```
+
+- [ ] **Step 3: Adjust search card layout for mobile**
+
+In the client-side `renderResults` function (around line 174), the search card already uses `flex justify-between items-start`. On mobile, the right-aligned date/restitution gets squished. Update the card template inside the `renderResults` function.
+
+Replace the card template (lines 172-189) in the `<script is:inline>` block:
+
+```javascript
+          return `
+            <a href="/pardon/details/${grant.slug}" class="search-card block no-underline mb-3">
+              <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2">
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 sm:gap-3 mb-2 flex-wrap">
+                    <span class="text-card-title font-medium text-text-primary truncate">${grant.name}</span>
+                    <span class="badge ${typeBadgeClass}">${typeLabel}</span>
+                    <span class="badge badge-category" style="color: ${catColor}">${catLabel}</span>
+                  </div>
+                  <p class="text-card-offense text-text-secondary mb-2 line-clamp-2">${grant.offense}</p>
+                  ${metaHtml}
+                </div>
+                <div class="flex sm:flex-col sm:text-right gap-3 sm:gap-0 sm:ml-4 flex-shrink-0 items-center sm:items-end">
+                  <div class="text-meta text-text-faint sm:mb-1">${grant.date}</div>
+                  ${restitutionHtml}
+                </div>
+              </div>
+            </a>
+          `;
+```
+
+- [ ] **Step 4: Verify search page on mobile**
+
+Run: `pnpm dev`, navigate to `/search`
+At 375px: search input is full-width, filter pills wrap, search cards stack vertically, date and restitution appear inline below the card content.
+At desktop: original side-by-side layout.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but commit -m "feat: responsive search page layout and cards"
+```
+
+---
+
+### Task 8: Responsive Detail Page Layout
+
+**Files:**
+- Modify: `src/pages/pardon/details/[slug].astro:175-316`
+
+- [ ] **Step 1: Update detail page container padding**
+
+In `src/pages/pardon/details/[slug].astro`, change line 175:
+
+```html
+<div class="max-w-detail mx-auto px-10 py-10">
+```
+
+to:
+
+```html
+<div class="max-w-detail mx-auto px-5 md:px-10 py-6 md:py-10">
+```
+
+- [ ] **Step 2: Add responsive detail-name font size**
+
+In `src/styles/global.css`, the `text-detail-name` size is set in `tailwind.config.ts` at 42px. We cannot use responsive prefixes on custom font sizes easily, so we'll use a class override. In `src/pages/pardon/details/[slug].astro`, change line 193-196:
+
+```html
+            <h1
+                class="font-serif text-text-primary text-detail-name m-0 mb-3"
+                style="letter-spacing: -0.02em;"
+            >
+```
+
+to:
+
+```html
+            <h1
+                class="font-serif text-text-primary m-0 mb-3 text-[28px] md:text-detail-name"
+                style="letter-spacing: -0.02em;"
+            >
+```
+
+- [ ] **Step 3: Make metadata grid responsive**
+
+Change line 260:
+
+```html
+<div class="grid grid-cols-2 gap-x-10 gap-y-5 mb-12">
+```
+
+to:
+
+```html
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-10 gap-y-5 mb-12">
+```
+
+- [ ] **Step 4: Reduce breadcrumb top margin on mobile**
+
+Change line 177:
+
+```html
+<div class="breadcrumb mb-10">
+```
+
+to:
+
+```html
+<div class="breadcrumb mb-6 md:mb-10">
+```
+
+- [ ] **Step 5: Reduce section margins on mobile**
+
+Change the hero stat wrapper (line 208):
+
+```html
+<div class="mb-10">
+```
+
+to:
+
+```html
+<div class="mb-6 md:mb-10">
+```
+
+Change the offenses wrapper (line 220):
+
+```html
+<div class="mb-10">
+```
+
+to:
+
+```html
+<div class="mb-6 md:mb-10">
+```
+
+Change the original sentence wrapper (line 247):
+
+```html
+<div class="mb-12">
+```
+
+to:
+
+```html
+<div class="mb-8 md:mb-12">
+```
+
+- [ ] **Step 6: Verify detail page on mobile**
+
+Run: `pnpm dev`, navigate to any pardon detail page
+At 375px: name is legible (~28px), metadata stacks single-column, spacing is tighter.
+At desktop: original layout preserved.
+
+- [ ] **Step 7: Commit**
+
+```bash
+but commit -m "feat: responsive detail page layout and typography"
+```
+
+---
+
+### Task 9: Responsive Footer
+
+**Files:**
+- Modify: `src/components/Footer.astro:13`
+
+- [ ] **Step 1: Update footer padding**
+
+In `src/components/Footer.astro`, change line 13:
+
+```html
+<div class="max-w-home mx-auto px-10 py-8">
+```
+
+to:
+
+```html
+<div class="max-w-home mx-auto px-5 md:px-10 py-8">
+```
+
+- [ ] **Step 2: Verify footer on mobile**
+
+Run: `pnpm dev`
+At 375px: footer text has comfortable 20px padding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+but commit -m "feat: responsive footer padding"
+```
+
+---
+
+### Task 10: Responsive Timeline
+
+**Files:**
+- Modify: `src/styles/global.css` (timeline-container, timeline-date)
+- Modify: `src/components/Timeline.astro:32`
+
+- [ ] **Step 1: Make timeline date and badge stack on mobile**
+
+In `src/components/Timeline.astro`, change line 32:
+
+```html
+<div class="flex items-baseline gap-4 mb-1.5">
+```
+
+to:
+
+```html
+<div class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4 mb-1.5">
+```
+
+- [ ] **Step 2: Reduce timeline left padding on mobile**
+
+In `src/styles/global.css`, replace `.timeline-container` (lines 280-283):
+
+```css
+  .timeline-container {
+    padding-left: 24px;
+    position: relative;
+  }
+
+  @media (min-width: 768px) {
+    .timeline-container {
+      padding-left: 32px;
+    }
+  }
+```
+
+- [ ] **Step 3: Adjust timeline-dot position for reduced padding**
+
+In `src/components/Timeline.astro`, change line 27:
+
+```html
+'timeline-dot absolute -left-8 top-1.5',
+```
+
+to:
+
+```html
+'timeline-dot absolute -left-6 sm:-left-8 top-1.5',
+```
+
+- [ ] **Step 4: Reduce timeline-date min-width on mobile**
+
+In `src/styles/global.css`, replace `.timeline-date` (lines 339-344):
+
+```css
+  .timeline-date {
+    font-size: 13px;
+    color: #7a7870;
+    font-weight: 500;
+    min-width: 0;
+  }
+
+  @media (min-width: 640px) {
+    .timeline-date {
+      min-width: 110px;
+    }
+  }
+```
+
+- [ ] **Step 5: Verify timeline on mobile**
+
+Run: `pnpm dev`
+At 375px: timeline entries stack date above badge, dots align with reduced padding.
+At desktop: original horizontal layout.
+
+- [ ] **Step 6: Commit**
+
+```bash
+but commit -m "feat: responsive timeline layout"
+```
+
+---
+
+### Task 11: Final Visual QA Pass
+
+**Files:** None — this is verification only.
+
+- [ ] **Step 1: Test all pages at mobile (375px)**
+
+Open Chrome DevTools, set to iPhone SE (375px). Navigate through:
+1. Home page — hero, stats, categories, timeline, source banner
+2. Search page — filters, results
+3. Detail page — breadcrumb, name, stats, offenses, metadata, sources
+
+Confirm no horizontal overflow on any page.
+
+- [ ] **Step 2: Test at tablet (768px)**
+
+Set to iPad Mini (768px). All grids should show intermediate column counts.
+
+- [ ] **Step 3: Test at desktop (1280px)**
+
+Confirm nothing regressed from the original desktop layout.
+
+- [ ] **Step 4: Final commit if any touch-ups needed**
+
+```bash
+but commit -m "fix: responsive design touch-ups from QA pass"
+```

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: "./data/pardonned.db",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -11,16 +11,31 @@
     "preview": "astro preview",
     "astro": "astro",
     "format": "oxfmt",
-    "lint": "oxlint"
+    "lint": "oxlint",
+    "scrape": "tsx src/scraper/scrape.ts --president all",
+    "scrape:trump2": "tsx src/scraper/scrape.ts --president trump-2",
+    "scrape:biden": "tsx src/scraper/scrape.ts --president biden-1",
+    "scrape:trump1": "tsx src/scraper/scrape.ts --president trump-1",
+    "scrape:obama": "tsx src/scraper/scrape.ts --president obama",
+    "scrape:bush": "tsx src/scraper/scrape.ts --president bush-jr",
+    "scrape:all": "tsx src/scraper/scrape.ts --president all",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.49.1",
-    "astro": "^6.1.3"
+    "astro": "^6.1.3",
+    "better-sqlite3": "^12.8.0",
+    "cheerio": "^1.2.0",
+    "dotenv": "^17.4.1",
+    "drizzle-orm": "^0.45.2",
+    "playwright": "^1.59.1"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "drizzle-kit": "^0.31.10",
     "oxfmt": "^0.43.0",
     "oxlint": "^1.58.0",
-    "tailwindcss": "^3.4.19"
+    "tailwindcss": "^3.4.19",
+    "tsx": "^4.21.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,34 @@ importers:
 
   .:
     dependencies:
-      '@supabase/supabase-js':
-        specifier: ^2.49.1
-        version: 2.101.1
       astro:
         specifier: ^6.1.3
-        version: 6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(yaml@2.8.3)
+        version: 6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(yaml@2.8.3)
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
+      cheerio:
+        specifier: ^1.2.0
+        version: 1.2.0
+      dotenv:
+        specifier: ^17.4.1
+        version: 17.4.1
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
     devDependencies:
       '@astrojs/tailwind':
         specifier: ^6.0.2
-        version: 6.0.2(astro@6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(yaml@2.8.3))(tailwindcss@3.4.19)
+        version: 6.0.2(astro@6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(yaml@2.8.3))(tailwindcss@3.4.19)
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       oxfmt:
         specifier: ^0.43.0
         version: 0.43.0
@@ -27,6 +45,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
 packages:
 
@@ -84,8 +105,25 @@ packages:
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.5':
     resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
@@ -93,10 +131,34 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.5':
     resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.5':
@@ -105,16 +167,52 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.5':
     resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.5':
     resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.5':
@@ -123,10 +221,34 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.5':
     resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.5':
@@ -135,10 +257,34 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.5':
     resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.5':
@@ -147,10 +293,34 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.5':
     resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.5':
@@ -159,10 +329,34 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.5':
     resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.5':
@@ -171,10 +365,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.5':
     resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.5':
@@ -183,16 +401,46 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.5':
     resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.5':
     resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.5':
@@ -201,10 +449,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.5':
     resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.5':
@@ -213,11 +479,29 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.5':
     resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.5':
     resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
@@ -225,16 +509,52 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.5':
     resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.5':
     resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.5':
@@ -801,32 +1121,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@supabase/auth-js@2.101.1':
-    resolution: {integrity: sha512-Kd0Wey+RkFHgyVep7adS6UOE2pN6MJ3mZ32PAXSvfw6IjUkFRC7IQpdZZjUOcUe5pXr1ejufCRgF6lsGINe4Tw==}
-    engines: {node: '>=20.0.0'}
-
-  '@supabase/functions-js@2.101.1':
-    resolution: {integrity: sha512-OZWU7YtaG+NNNFZK8p/FuJ6gpq7pFyrG2fLOopP73HAIDHDGpOttPJapvO8ADu3RkqfQfkwrB354vPkSBbZ20A==}
-    engines: {node: '>=20.0.0'}
-
-  '@supabase/phoenix@0.4.0':
-    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
-
-  '@supabase/postgrest-js@2.101.1':
-    resolution: {integrity: sha512-UW1RajH5jbZoK+ldAJ1I6VZ+HWwZ2oaKjEQ6Gn+AQ67CHQVxGl8wNQoLYyumbyaExm41I+wn7arulcY1eHeZJw==}
-    engines: {node: '>=20.0.0'}
-
-  '@supabase/realtime-js@2.101.1':
-    resolution: {integrity: sha512-Oa6dno0OB9I+hv5do5zsZHbFu41ViZnE9IWjmkeeF/8fPmB5fWoHGqeTYEC3/0DAgtpUoFJa4FpvzFH0SBHo1Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@supabase/storage-js@2.101.1':
-    resolution: {integrity: sha512-WhTaUOBgeEvnKLy95Cdlp6+D5igSF/65yC727w1olxbet5nzUvMlajKUWyzNtQu2efrz2cQ7FcdVBdQqgT9YKQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@supabase/supabase-js@2.101.1':
-    resolution: {integrity: sha512-Jnhm3LfuACwjIzvk2pfUbGQn7pa7hi6MFzfSyPrRYWVCCu69RPLCFyHSBl7HSBwadbQ3UZOznnD3gPca3ePrRA==}
-    engines: {node: '>=20.0.0'}
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -851,9 +1147,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -897,14 +1190,27 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.13:
     resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -917,6 +1223,12 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -937,6 +1249,13 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -944,6 +1263,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -1014,6 +1336,14 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   defu@6.1.6:
     resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
 
@@ -1057,12 +1387,118 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv@17.4.1:
+    resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
+    engines: {node: '>=12'}
+
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1072,8 +1508,22 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.5:
     resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
@@ -1093,6 +1543,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1122,6 +1576,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1140,6 +1597,14 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1147,6 +1612,12 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1202,12 +1673,24 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
-  iceberg-js@0.8.1:
-    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
-    engines: {node: '>=20.0.0'}
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -1418,6 +1901,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1433,12 +1926,19 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -1472,6 +1972,9 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
@@ -1512,6 +2015,12 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -1539,6 +2048,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -1581,6 +2100,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -1588,14 +2113,25 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -1642,6 +2178,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -1671,6 +2210,12 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -1688,6 +2233,12 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -1699,11 +2250,25 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -1723,6 +2288,13 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1776,6 +2348,14 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -1787,6 +2367,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1952,21 +2536,21 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -2030,9 +2614,9 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/tailwind@6.0.2(astro@6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(yaml@2.8.3))(tailwindcss@3.4.19)':
+  '@astrojs/tailwind@6.0.2(astro@6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(yaml@2.8.3))(tailwindcss@3.4.19)':
     dependencies:
-      astro: 6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(yaml@2.8.3)
+      astro: 6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(yaml@2.8.3)
       autoprefixer: 10.4.27(postcss@8.5.8)
       postcss: 8.5.8
       postcss-load-config: 4.0.2(postcss@8.5.8)
@@ -2081,84 +2665,240 @@ snapshots:
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.13.7
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.5':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.5':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.5':
     optional: true
 
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.5':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.5':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.5':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.5':
@@ -2526,45 +3266,9 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@supabase/auth-js@2.101.1':
+  '@types/better-sqlite3@7.6.13':
     dependencies:
-      tslib: 2.8.1
-
-  '@supabase/functions-js@2.101.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@supabase/phoenix@0.4.0': {}
-
-  '@supabase/postgrest-js@2.101.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@supabase/realtime-js@2.101.1':
-    dependencies:
-      '@supabase/phoenix': 0.4.0
-      '@types/ws': 8.18.1
-      tslib: 2.8.1
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@supabase/storage-js@2.101.1':
-    dependencies:
-      iceberg-js: 0.8.1
-      tslib: 2.8.1
-
-  '@supabase/supabase-js@2.101.1':
-    dependencies:
-      '@supabase/auth-js': 2.101.1
-      '@supabase/functions-js': 2.101.1
-      '@supabase/postgrest-js': 2.101.1
-      '@supabase/realtime-js': 2.101.1
-      '@supabase/storage-js': 2.101.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+      '@types/node': 25.5.0
 
   '@types/debug@4.1.13':
     dependencies:
@@ -2592,10 +3296,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 25.5.0
-
   '@ungap/structured-clone@1.3.0': {}
 
   any-promise@1.3.0: {}
@@ -2613,7 +3313,7 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
-  astro@6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(yaml@2.8.3):
+  astro@6.1.3(@types/node@25.5.0)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -2665,8 +3365,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.8.3)
-      vitefu: 1.1.3(vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.8.3))
+      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -2720,9 +3420,26 @@ snapshots:
 
   bail@2.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.13: {}
 
+  better-sqlite3@12.8.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   boolbase@1.0.0: {}
 
@@ -2738,6 +3455,13 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001784: {}
@@ -2749,6 +3473,29 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   character-entities@2.0.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.24.7
+      whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -2765,6 +3512,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   ci-info@4.4.0: {}
 
@@ -2820,14 +3569,19 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   defu@6.1.6: {}
 
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   devalue@5.6.4: {}
 
@@ -2859,15 +3613,94 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv@17.4.1: {}
+
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.8.0
+
   dset@3.1.4: {}
 
   electron-to-chromium@1.5.331: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@4.5.0: {}
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   es-module-lexer@2.0.0: {}
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.5:
     optionalDependencies:
@@ -2906,6 +3739,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expand-template@2.0.3: {}
+
   extend@3.0.2: {}
 
   fast-glob@3.3.3:
@@ -2934,6 +3769,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -2950,10 +3787,21 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fs-constants@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -3072,9 +3920,24 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
 
-  iceberg-js@0.8.1: {}
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -3454,6 +4317,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -3466,11 +4335,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
 
   node-fetch-native@1.6.7: {}
 
@@ -3497,6 +4372,10 @@ snapshots:
       ufo: 1.6.3
 
   ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-parser@0.12.1: {}
 
@@ -3574,6 +4453,15 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -3591,6 +4479,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.8):
     dependencies:
@@ -3629,17 +4525,50 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -3723,6 +4652,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -3791,6 +4722,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
   sax@1.6.0: {}
 
   semver@7.7.4: {}
@@ -3838,18 +4773,39 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sisteransi@1.0.5: {}
 
   smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
   space-separated-tokens@2.0.2: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-json-comments@2.0.1: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -3900,6 +4856,21 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -3933,7 +4904,19 @@ snapshots:
 
   tsconfck@3.1.6: {}
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.5
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ufo@1.6.3: {}
 
@@ -3942,6 +4925,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.24.7: {}
 
   unified@11.0.5:
     dependencies:
@@ -4035,7 +5020,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.8.3):
+  vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.5
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4047,17 +5032,24 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 1.21.7
+      tsx: 4.21.0
       yaml: 2.8.3
 
-  vitefu@1.1.3(vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3)
 
   web-namespaces@2.0.1: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   which-pm-runs@1.1.0: {}
 
-  ws@8.20.0: {}
+  wrappy@1.0.2: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -6,9 +6,7 @@ import {
 
 const pardonDetails = defineCollection({
   loader: pardonDetailsLoader({
-    filters: {
-      administration_slug: "eq.trump-2",
-    },
+    administrationSlug: "trump-2",
   }),
   schema: pardonDetailSchema,
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,72 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+export const administrations = sqliteTable("administrations", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  slug: text("slug").unique().notNull(),
+  president_name: text("president_name").notNull(),
+  term_number: integer("term_number").notNull(),
+  start_date: text("start_date").notNull(),
+  end_date: text("end_date"),
+  created_at: text("created_at")
+    .default(sql`datetime('now')`)
+    .notNull(),
+  updated_at: text("updated_at")
+    .default(sql`datetime('now')`)
+    .notNull(),
+});
+
+export const pardons = sqliteTable(
+  "pardons",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    administration: integer("administration")
+      .notNull()
+      .references(() => administrations.id),
+    recipient_name: text("recipient_name").notNull(),
+    clemency_type: text("clemency_type", {
+      enum: ["pardon", "commutation"],
+    }).notNull(),
+    grant_date: text("grant_date").notNull(),
+    warrant_url: text("warrant_url"),
+    source_url: text("source_url"),
+    district: text("district"),
+    offense: text("offense").notNull(),
+    offense_category: text("offense_category", {
+      enum: [
+        "violent crime",
+        "fraud",
+        "drug offense",
+        "FACE act",
+        "immigration",
+        "firearms",
+        "financial crime",
+        "other",
+      ],
+    }).notNull(),
+    sentence_in_months: integer("sentence_in_months"),
+    fine: real("fine"),
+    restitution: real("restitution"),
+    original_sentence: text("original_sentence"),
+    created_at: text("created_at")
+      .default(sql`datetime('now')`)
+      .notNull(),
+    updated_at: text("updated_at")
+      .default(sql`datetime('now')`)
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("pardons_admin_recipient_date_type_unique").on(
+      table.administration,
+      table.recipient_name,
+      table.grant_date,
+      table.clemency_type,
+    ),
+  ],
+);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="astro/client" />
 
 interface ImportMetaEnv {
-  readonly PARDONNED_API_HOST: string;
-  readonly PARDONNED_API_KEY: string;
+  readonly PARDONNED_DB: string;
 }
 
 interface ImportMeta {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,484 @@
+import "dotenv/config";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq, inArray, sql } from "drizzle-orm";
+import * as schema from "../db/schema.js";
+import { administrations, pardons } from "../db/schema.js";
+import type { ParsedGrant } from "./parsers/types.js";
+import { parseSentence } from "./parsers/sentences.js";
+import { mkdirSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS administrations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT UNIQUE NOT NULL,
+  president_name TEXT NOT NULL,
+  term_number INTEGER NOT NULL,
+  start_date TEXT NOT NULL,
+  end_date TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS pardons (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  administration INTEGER NOT NULL REFERENCES administrations(id),
+  recipient_name TEXT NOT NULL,
+  clemency_type TEXT NOT NULL CHECK(clemency_type IN ('pardon','commutation')),
+  grant_date TEXT NOT NULL,
+  warrant_url TEXT,
+  source_url TEXT,
+  district TEXT,
+  offense TEXT NOT NULL,
+  offense_category TEXT NOT NULL CHECK(offense_category IN ('violent crime','fraud','drug offense','FACE act','immigration','firearms','financial crime','other')),
+  sentence_in_months INTEGER,
+  fine REAL,
+  restitution REAL,
+  original_sentence TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(administration, recipient_name, grant_date, clemency_type)
+);
+`;
+
+type AdminInsert = typeof administrations.$inferInsert;
+
+const SEED_ADMINISTRATIONS: AdminInsert[] = [
+  {
+    slug: "mckinley-1",
+    president_name: "William McKinley",
+    term_number: 1,
+    start_date: "1897-03-04",
+    end_date: "1901-03-04",
+  },
+  {
+    slug: "mckinley-2",
+    president_name: "William McKinley",
+    term_number: 2,
+    start_date: "1901-03-04",
+    end_date: "1901-09-14",
+  },
+  {
+    slug: "t-roosevelt-1",
+    president_name: "Theodore Roosevelt",
+    term_number: 1,
+    start_date: "1901-09-14",
+    end_date: "1905-03-04",
+  },
+  {
+    slug: "t-roosevelt-2",
+    president_name: "Theodore Roosevelt",
+    term_number: 2,
+    start_date: "1905-03-04",
+    end_date: "1909-03-04",
+  },
+  {
+    slug: "taft-1",
+    president_name: "William H. Taft",
+    term_number: 1,
+    start_date: "1909-03-04",
+    end_date: "1913-03-04",
+  },
+  {
+    slug: "wilson-1",
+    president_name: "Woodrow Wilson",
+    term_number: 1,
+    start_date: "1913-03-04",
+    end_date: "1917-03-04",
+  },
+  {
+    slug: "wilson-2",
+    president_name: "Woodrow Wilson",
+    term_number: 2,
+    start_date: "1917-03-04",
+    end_date: "1921-03-04",
+  },
+  {
+    slug: "harding-1",
+    president_name: "Warren Harding",
+    term_number: 1,
+    start_date: "1921-03-04",
+    end_date: "1923-08-02",
+  },
+  {
+    slug: "coolidge-1",
+    president_name: "Calvin Coolidge",
+    term_number: 1,
+    start_date: "1923-08-02",
+    end_date: "1925-03-04",
+  },
+  {
+    slug: "coolidge-2",
+    president_name: "Calvin Coolidge",
+    term_number: 2,
+    start_date: "1925-03-04",
+    end_date: "1929-03-04",
+  },
+  {
+    slug: "hoover-1",
+    president_name: "Herbert Hoover",
+    term_number: 1,
+    start_date: "1929-03-04",
+    end_date: "1933-03-04",
+  },
+  {
+    slug: "fdr-1",
+    president_name: "Franklin D. Roosevelt",
+    term_number: 1,
+    start_date: "1933-03-04",
+    end_date: "1937-01-20",
+  },
+  {
+    slug: "fdr-2",
+    president_name: "Franklin D. Roosevelt",
+    term_number: 2,
+    start_date: "1937-01-20",
+    end_date: "1941-01-20",
+  },
+  {
+    slug: "fdr-3",
+    president_name: "Franklin D. Roosevelt",
+    term_number: 3,
+    start_date: "1941-01-20",
+    end_date: "1945-01-20",
+  },
+  {
+    slug: "fdr-4",
+    president_name: "Franklin D. Roosevelt",
+    term_number: 4,
+    start_date: "1945-01-20",
+    end_date: "1945-04-12",
+  },
+  {
+    slug: "truman-1",
+    president_name: "Harry S. Truman",
+    term_number: 1,
+    start_date: "1945-04-12",
+    end_date: "1949-01-20",
+  },
+  {
+    slug: "truman-2",
+    president_name: "Harry S. Truman",
+    term_number: 2,
+    start_date: "1949-01-20",
+    end_date: "1953-01-20",
+  },
+  {
+    slug: "eisenhower-1",
+    president_name: "Dwight D. Eisenhower",
+    term_number: 1,
+    start_date: "1953-01-20",
+    end_date: "1957-01-20",
+  },
+  {
+    slug: "eisenhower-2",
+    president_name: "Dwight D. Eisenhower",
+    term_number: 2,
+    start_date: "1957-01-20",
+    end_date: "1961-01-20",
+  },
+  {
+    slug: "kennedy-1",
+    president_name: "John F. Kennedy",
+    term_number: 1,
+    start_date: "1961-01-20",
+    end_date: "1963-11-22",
+  },
+  {
+    slug: "lbj-1",
+    president_name: "Lyndon B. Johnson",
+    term_number: 1,
+    start_date: "1963-11-22",
+    end_date: "1965-01-20",
+  },
+  {
+    slug: "lbj-2",
+    president_name: "Lyndon B. Johnson",
+    term_number: 2,
+    start_date: "1965-01-20",
+    end_date: "1969-01-20",
+  },
+  {
+    slug: "nixon-1",
+    president_name: "Richard M. Nixon",
+    term_number: 1,
+    start_date: "1969-01-20",
+    end_date: "1973-01-20",
+  },
+  {
+    slug: "nixon-2",
+    president_name: "Richard M. Nixon",
+    term_number: 2,
+    start_date: "1973-01-20",
+    end_date: "1974-08-09",
+  },
+  {
+    slug: "ford-1",
+    president_name: "Gerald R. Ford Jr.",
+    term_number: 1,
+    start_date: "1974-08-09",
+    end_date: "1977-01-20",
+  },
+  {
+    slug: "carter-1",
+    president_name: "Jimmy E. Carter",
+    term_number: 1,
+    start_date: "1977-01-20",
+    end_date: "1981-01-20",
+  },
+  {
+    slug: "reagan-1",
+    president_name: "Ronald W. Reagan",
+    term_number: 1,
+    start_date: "1981-01-20",
+    end_date: "1985-01-20",
+  },
+  {
+    slug: "reagan-2",
+    president_name: "Ronald W. Reagan",
+    term_number: 2,
+    start_date: "1985-01-20",
+    end_date: "1989-01-20",
+  },
+  {
+    slug: "bush-sr",
+    president_name: "George H.W. Bush",
+    term_number: 1,
+    start_date: "1989-01-20",
+    end_date: "1993-01-20",
+  },
+  {
+    slug: "clinton-1",
+    president_name: "William J. Clinton",
+    term_number: 1,
+    start_date: "1993-01-20",
+    end_date: "1997-01-20",
+  },
+  {
+    slug: "clinton-2",
+    president_name: "William J. Clinton",
+    term_number: 2,
+    start_date: "1997-01-20",
+    end_date: "2001-01-20",
+  },
+  {
+    slug: "bush-jr-1",
+    president_name: "George W. Bush",
+    term_number: 1,
+    start_date: "2001-01-20",
+    end_date: "2005-01-20",
+  },
+  {
+    slug: "bush-jr-2",
+    president_name: "George W. Bush",
+    term_number: 2,
+    start_date: "2005-01-20",
+    end_date: "2009-01-20",
+  },
+  {
+    slug: "obama-1",
+    president_name: "Barack H. Obama",
+    term_number: 1,
+    start_date: "2009-01-20",
+    end_date: "2013-01-20",
+  },
+  {
+    slug: "obama-2",
+    president_name: "Barack H. Obama",
+    term_number: 2,
+    start_date: "2013-01-20",
+    end_date: "2017-01-20",
+  },
+  {
+    slug: "trump-1",
+    president_name: "Donald J. Trump",
+    term_number: 1,
+    start_date: "2017-01-20",
+    end_date: "2021-01-20",
+  },
+  {
+    slug: "biden-1",
+    president_name: "Joseph R. Biden",
+    term_number: 1,
+    start_date: "2021-01-20",
+    end_date: "2025-01-20",
+  },
+  {
+    slug: "trump-2",
+    president_name: "Donald J. Trump",
+    term_number: 2,
+    start_date: "2025-01-20",
+    end_date: null,
+  },
+];
+
+function getDbPath(): string {
+  const raw = process.env.PARDONNED_DB;
+  if (!raw) {
+    throw new Error("Missing required environment variable: PARDONNED_DB");
+  }
+
+  const dbPath = resolve(raw);
+  const dir = resolve(dbPath, "..");
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  return dbPath;
+}
+
+const sqlite = new Database(getDbPath());
+sqlite.exec(DDL);
+
+export const db = drizzle(sqlite, { schema });
+
+const adminCount = db
+  .select({ count: sql<number>`count(*)` })
+  .from(administrations)
+  .get()!;
+if (adminCount.count === 0) {
+  db.insert(administrations).values(SEED_ADMINISTRATIONS).run();
+  console.log(`Seeded ${SEED_ADMINISTRATIONS.length} administrations`);
+}
+
+const termIdCache = new Map<string, number>();
+
+export async function getTermId(slug: string): Promise<number> {
+  const cached = termIdCache.get(slug);
+  if (cached !== undefined) return cached;
+
+  const row = db
+    .select({ id: administrations.id })
+    .from(administrations)
+    .where(eq(administrations.slug, slug))
+    .get();
+
+  if (!row) {
+    throw new Error(`Could not find an administration for "${slug}"`);
+  }
+
+  termIdCache.set(slug, row.id);
+  return row.id;
+}
+
+export async function getTermForDate(
+  slugs: string[],
+  grantDate: string,
+): Promise<string> {
+  if (slugs.length === 1) return slugs[0];
+
+  const data = db
+    .select({
+      id: administrations.id,
+      slug: administrations.slug,
+      start_date: administrations.start_date,
+      end_date: administrations.end_date,
+    })
+    .from(administrations)
+    .where(inArray(administrations.slug, slugs))
+    .all();
+
+  if (!data.length) {
+    throw new Error(`administration not found for slugs ${slugs.join(", ")}`);
+  }
+
+  for (const term of data) {
+    const start = term.start_date;
+    const end = term.end_date || "9999-12-31";
+    if (grantDate >= start && grantDate < end) {
+      termIdCache.set(term.slug, term.id);
+      return term.slug;
+    }
+  }
+
+  const last = data[data.length - 1];
+  termIdCache.set(last.slug, last.id);
+  return last.slug;
+}
+
+export async function upsertGrants(
+  grants: ParsedGrant[],
+  slugs: string[],
+): Promise<{ inserted: number; skipped: number }> {
+  let inserted = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < grants.length; i += 50) {
+    const batch = grants.slice(i, i + 50);
+
+    const rows = await Promise.all(
+      batch.map(async (g) => {
+        const slug = await getTermForDate(slugs, g.grant_date);
+        const administration = await getTermId(slug);
+        const parsed = g.sentence ? parseSentence(g.sentence) : [];
+        const first = parsed[0] ?? null;
+
+        return {
+          administration,
+          recipient_name: g.recipient_name,
+          clemency_type: g.pardon_type,
+          grant_date: g.grant_date,
+          warrant_url: g.warrant_url,
+          source_url: g.source_url,
+          district: g.district,
+          offense: g.offense,
+          offense_category: g.offense_category,
+          sentence_in_months: first?.sentence_in_months ?? null,
+          fine: first?.fine ?? null,
+          restitution: first?.restitution ?? null,
+          original_sentence: g.sentence ?? null,
+        };
+      }),
+    );
+
+    const seen = new Set<string>();
+    const deduped = rows.filter((r) => {
+      const key = `${r.administration}|${r.recipient_name}|${r.grant_date}|${r.clemency_type}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    if (deduped.length < rows.length) {
+      console.log(
+        `  Deduped batch at index ${i}: ${rows.length} → ${deduped.length}`,
+      );
+    }
+
+    try {
+      const result = db
+        .insert(pardons)
+        .values(deduped)
+        .onConflictDoUpdate({
+          target: [
+            pardons.administration,
+            pardons.recipient_name,
+            pardons.grant_date,
+            pardons.clemency_type,
+          ],
+          set: {
+            warrant_url: sql`excluded.warrant_url`,
+            source_url: sql`excluded.source_url`,
+            district: sql`excluded.district`,
+            offense: sql`excluded.offense`,
+            offense_category: sql`excluded.offense_category`,
+            sentence_in_months: sql`excluded.sentence_in_months`,
+            fine: sql`excluded.fine`,
+            restitution: sql`excluded.restitution`,
+            original_sentence: sql`excluded.original_sentence`,
+            updated_at: sql`datetime('now')`,
+          },
+        })
+        .run();
+
+      inserted += result.changes;
+    } catch (err) {
+      console.error(`Error upserting batch at index ${i}:`, err);
+      skipped += batch.length;
+    }
+  }
+
+  return { inserted, skipped };
+}

--- a/src/lib/parsers/categorize.ts
+++ b/src/lib/parsers/categorize.ts
@@ -1,0 +1,45 @@
+import type { OffenseCategory } from "./types.js";
+
+const CATEGORY_PATTERNS: Record<OffenseCategory, RegExp[]> = {
+  "violent crime": [
+    /\b(murder|homicide|manslaughter|assault|battery|kidnap(?:ping)?|robbery|rape|sexual\s+assault|domestic\s+violence|arson|carjacking|violence|violent|armed\s+robbery)\b/i,
+    /\b(conspiracy\s+to\s+(commit\s+)?(murder|assault|kidnap|robbery))\b/i,
+  ],
+  fraud: [
+    /\b(fraud|embezzlement|false\s+statements|perjury|mail\s+fraud|wire\s+fraud|tax\s+fraud|bank\s+fraud|health\s+care\s+fraud|medicare\s+fraud|identity\s+theft|forgery|racketeering)\b/i,
+  ],
+  "drug offense": [
+    /\b(drug|narcotic|cocaine|heroin|marijuana|methamphetamine|fentanyl|opioid|controlled\s+substance|possession\s+with\s+intent|distribution\s+of|trafficking|conspiracy\s+to\s+distribute)\b/i,
+  ],
+  "FACE act": [
+    /\b(face\s+act|freedom\s+of\s+access\s+to\s+clinic\s+entrances|clinic\s+entrance|reproductive\s+health\s+care\s+facility|obstruction\s+of\s+clinic)\b/i,
+  ],
+  immigration: [
+    /\b(immigration|illegal\s+entry|illegal\s+reentry|alien\s+smuggling|human\s+smuggling|border\s+patrol|undocumented|deportation|removal|visa\s+fraud|illegal\s+presence)\b/i,
+  ],
+  firearms: [
+    /\b(firearm|gun|weapon|possess(?:ion)?\s+(?:of\s+)?(?:a\s+)?(?:firearm|gun|weapon)|felon\s+in\s+possession|straw\s+purchas(?:e|ing)|illegal\s+transfer)\b/i,
+  ],
+  "financial crime": [
+    /\b(money\s+laundering|tax\s+evasion|structuring|currency\s+transaction|financial\s+institution|bank\s+secrecy|racketeer|bribery|corruption|kickback)\b/i,
+  ],
+  other: [],
+};
+
+export function categorizeOffense(offense: string): OffenseCategory {
+  const text = offense.toLowerCase();
+
+  for (const [category, patterns] of Object.entries(CATEGORY_PATTERNS) as [
+    OffenseCategory,
+    RegExp[],
+  ][]) {
+    if (category === "other") continue;
+    for (const pattern of patterns) {
+      if (pattern.test(text)) {
+        return category;
+      }
+    }
+  }
+
+  return "other";
+}

--- a/src/lib/parsers/detect.ts
+++ b/src/lib/parsers/detect.ts
@@ -1,0 +1,50 @@
+import * as cheerio from "cheerio";
+import type { PageFormat } from "./types.js";
+
+/**
+ * Auto-detect the page format by inspecting the first table's structure.
+ *
+ * Format A (trump2025): <th> contains "NAME and WARRANT"
+ * Format B (table-five): <th> contains "PUBLIC DISCLOSURE"
+ * Format C (table-four): <th> contains "NAME" with 4 columns
+ * Format D (key-value): No <th> headers, 2 columns
+ */
+export function detectFormat(html: string): PageFormat {
+  const $ = cheerio.load(html);
+
+  const firstTable = $("table").first();
+  if (!firstTable.length) {
+    throw new Error("No tables found on page — cannot detect format");
+  }
+
+  const headers = firstTable
+    .find("th")
+    .map((_i, th) => $(th).text().trim().toUpperCase())
+    .get();
+
+  if (headers.some((h: string) => h.includes("NAME AND WARRANT"))) {
+    return "trump2025";
+  }
+
+  if (headers.some((h: string) => h.includes("PUBLIC DISCLOSURE"))) {
+    return "table-five";
+  }
+
+  if (headers.some((h: string) => h === "NAME") && headers.length === 4) {
+    return "table-four";
+  }
+
+  // No headers or non-standard — check column count
+  const firstRow = firstTable.find("tr").first();
+  const cellCount = firstRow.find("td").length;
+  if (cellCount <= 2 && headers.length === 0) {
+    return "key-value";
+  }
+
+  // Fallback: if there are headers but we didn't match, try table-four
+  if (headers.length >= 3) {
+    return "table-four";
+  }
+
+  return "key-value";
+}

--- a/src/lib/parsers/key-value.ts
+++ b/src/lib/parsers/key-value.ts
@@ -1,0 +1,361 @@
+import * as cheerio from "cheerio";
+import type { ParsedGrant } from "./types.js";
+import { categorizeOffense } from "./categorize.js";
+
+type CheerioTable = cheerio.Cheerio<any>;
+
+/**
+ * Format D — Obama and earlier (separate pardons/commutations pages).
+ *
+ * These pages use 2-column key-value tables with variable rows per person.
+ *
+ * Pardons (3 rows per person):
+ *   [empty, Name] → ["Offense:", text(District)] → ["Sentence:", text]
+ *
+ * Commutations (4-5+ rows per person):
+ *   [empty, Name] → ["Offense:", text] → ["District/Date:", text]
+ *   → ["Sentence:", text] → optional ["Terms of grant:", text]
+ *   → optional continuation rows [empty, "2. ..."]
+ *
+ * Bush commutations use a SINGLE table with 1-cell date separator rows.
+ *
+ * The parser uses label-based accumulation: a new person starts only when
+ * we see an empty-label row whose value looks like a name (not a numbered
+ * continuation like "2. 45 months...").
+ */
+export function parseKeyValue(
+  html: string,
+  pardonType: "pardon" | "commutation",
+  sourceUrl: string,
+): ParsedGrant[] {
+  const $ = cheerio.load(html);
+  const grants: ParsedGrant[] = [];
+
+  // Strategy: collect date headings and tables, then match them.
+  // Some pages interleave headings and tables (1:1 mapping by position),
+  // while others have a single table with in-line date rows.
+
+  const dateHeadings = $("h2")
+    .filter((_i, h) => parseDate($(h).text().trim()) !== null)
+    .toArray();
+
+  const tables = $("table").toArray();
+
+  if (dateHeadings.length > 0 && tables.length > 0) {
+    // Use nextUntil to find tables between each heading and the next H2
+    let matched = 0;
+    for (const heading of dateHeadings) {
+      const headingText = $(heading).text().trim();
+      const dateStr = parseDate(headingText)!;
+
+      const betweenTables = $(heading).nextUntil("h2").filter("table");
+      betweenTables.each((_ti, tbl) => {
+        const tableGrants = parseTable(
+          $,
+          $(tbl),
+          pardonType,
+          sourceUrl,
+          dateStr,
+        );
+        grants.push(...tableGrants);
+      });
+      matched += betweenTables.length;
+    }
+
+    if (matched > 0) return grants;
+  }
+
+  // Fallback: process all tables directly (handles single-table with in-line dates)
+  console.log(
+    `    [key-value] Fallback: processing ${tables.length} tables with inline dates`,
+  );
+  for (const table of tables) {
+    const tableGrants = parseTable(
+      $,
+      $(table),
+      pardonType,
+      sourceUrl,
+      null, // date will come from in-line date rows
+    );
+    grants.push(...tableGrants);
+  }
+
+  return grants;
+}
+
+function parseTable(
+  $: cheerio.CheerioAPI,
+  table: CheerioTable,
+  pardonType: "pardon" | "commutation",
+  sourceUrl: string,
+  defaultDate: string | null,
+): ParsedGrant[] {
+  const grants: ParsedGrant[] = [];
+  const rows = table.find("tr");
+
+  let current: PersonRecord | null = null;
+  let currentDate = defaultDate;
+  let lastField: string | null = null; // Track which field was last set for continuations
+
+  rows.each((_r, row) => {
+    const cells = $(row).find("td");
+
+    // Check for <th> name rows (older Obama format uses TH for person names)
+    if (cells.length === 0) {
+      const thCells = $(row).find("th");
+      if (thCells.length > 0) {
+        // TH rows contain person names — process each TH as a separate person
+        thCells.each((_ti, th) => {
+          const name = $(th).text().trim();
+          if (name && isNameValue(name)) {
+            // Flush previous person
+            if (current?.name && currentDate) {
+              grants.push(
+                buildGrant(current, pardonType, currentDate, sourceUrl),
+              );
+            }
+            current = {
+              name,
+              offense: null,
+              district: null,
+              sentence: null,
+              terms: null,
+            };
+            lastField = null;
+          }
+        });
+      }
+      return;
+    }
+
+    // Single-cell row: could be an in-line date separator OR a name (older format)
+    if (cells.length === 1) {
+      const cellText = cells.eq(0).text().trim();
+      if (!cellText) return;
+
+      const parsed = parseDate(cellText);
+      if (parsed) {
+        // Date separator row
+        if (current?.name) {
+          grants.push(buildGrant(current, pardonType, currentDate!, sourceUrl));
+          current = null;
+        }
+        currentDate = parsed;
+      } else if (isNameValue(cellText)) {
+        // Single-cell name row (older Obama format: name in one cell, no empty first col)
+        if (current?.name && currentDate) {
+          grants.push(buildGrant(current, pardonType, currentDate, sourceUrl));
+        }
+        current = {
+          name: cellText,
+          offense: null,
+          district: null,
+          sentence: null,
+          terms: null,
+        };
+        lastField = null;
+      }
+      return;
+    }
+
+    const label = cells.eq(0).text().trim();
+    const value = cells.eq(1).text().trim();
+
+    if (label === "") {
+      // Empty label: either a new person name or a continuation row
+      if (isNameValue(value)) {
+        // Flush previous person
+        if (current?.name && currentDate) {
+          grants.push(buildGrant(current, pardonType, currentDate, sourceUrl));
+        }
+        current = {
+          name: value,
+          offense: null,
+          district: null,
+          sentence: null,
+          terms: null,
+        };
+        lastField = null;
+      } else if (current && lastField) {
+        // Continuation row — append to the last field
+        appendToField(current, lastField, value);
+      }
+    } else if (current) {
+      const normalizedLabel = label.toLowerCase().replace(/[:\s]/g, "");
+
+      if (normalizedLabel === "offense" || normalizedLabel === "offenses") {
+        current.offense = value;
+        lastField = "offense";
+      } else if (
+        normalizedLabel === "district" ||
+        normalizedLabel.includes("district") ||
+        normalizedLabel === "district/date"
+      ) {
+        const parsed = parseDistrictDate(value);
+        current.district = parsed.district;
+        lastField = "district";
+      } else if (normalizedLabel === "sentence") {
+        current.sentence = value;
+        lastField = "sentence";
+      } else if (normalizedLabel === "sentenced") {
+        current.sentence = value;
+        lastField = "sentence";
+      } else if (
+        normalizedLabel === "termsofgrant" ||
+        normalizedLabel === "terms"
+      ) {
+        current.terms = value;
+        lastField = "terms";
+      }
+    }
+  });
+
+  // Flush last person
+  if (current !== null && currentDate) {
+    grants.push(buildGrant(current, pardonType, currentDate, sourceUrl));
+  }
+
+  return grants;
+}
+
+interface PersonRecord {
+  name: string;
+  offense: string | null;
+  district: string | null;
+  sentence: string | null;
+  terms: string | null;
+}
+
+/**
+ * Determine if a value in an empty-label row is a person's name (vs a continuation).
+ * Continuation rows typically start with a number+period like "2." or "3."
+ */
+function isNameValue(value: string): boolean {
+  if (!value) return false;
+  // Numbered continuations: "2. 45 months' imprisonment..."
+  if (/^\d+\./.test(value)) return false;
+  // Sentence-like continuations that start with lowercase or special chars
+  if (/^[a-z(]/.test(value)) return false;
+  // Values that look like sentences (contain common sentence keywords right at start)
+  if (
+    /^(?:Life|Time served|No punishment)/i.test(value) &&
+    !value.includes(",")
+  ) {
+    // Could be a name like "Life" or a sentence — check for imprisonment keywords
+    if (/imprisonment|probation|supervised|confinement/i.test(value))
+      return false;
+  }
+  return true;
+}
+
+function appendToField(
+  person: PersonRecord,
+  field: string,
+  value: string,
+): void {
+  switch (field) {
+    case "offense":
+      person.offense = person.offense ? `${person.offense}; ${value}` : value;
+      break;
+    case "sentence":
+      person.sentence = person.sentence
+        ? `${person.sentence}; ${value}`
+        : value;
+      break;
+    case "district":
+      person.district = person.district
+        ? `${person.district}; ${value}`
+        : value;
+      break;
+    case "terms":
+      person.terms = person.terms ? `${person.terms}; ${value}` : value;
+      break;
+  }
+}
+
+function buildGrant(
+  person: PersonRecord,
+  pardonType: "pardon" | "commutation",
+  grantDate: string,
+  sourceUrl: string,
+): ParsedGrant {
+  let offense = person.offense || "";
+  let district = person.district;
+
+  // If no separate district field, try extracting from offense text
+  if (!district && offense) {
+    const extracted = extractDistrict(offense);
+    offense = extracted.offense;
+    district = extracted.district;
+  }
+
+  // Append terms to sentence if present
+  let sentence = person.sentence;
+  if (person.terms) {
+    sentence = sentence ? `${sentence} (Terms: ${person.terms})` : person.terms;
+  }
+
+  return {
+    recipient_name: person.name,
+    warrant_url: null,
+    district,
+    sentence,
+    offense,
+    offense_category: categorizeOffense(offense),
+    pardon_type: pardonType,
+    grant_date: grantDate,
+    source_url: sourceUrl,
+  };
+}
+
+function parseDistrictDate(text: string): { district: string | null } {
+  // Handle formats like:
+  // "District of Maryland; October 8, 2008"
+  // "1. & 2. District of South Carolina; 1. & 2. December 18, 2008"
+  const parts = text.split(";");
+  const district = parts[0]?.trim() || null;
+  return { district };
+}
+
+function extractDistrict(offenseText: string): {
+  offense: string;
+  district: string | null;
+} {
+  const districtPattern =
+    /\(([^)]*(?:District|Division|Court|Puerto Rico|Guam|Virgin Islands)[^)]*)\)\s*$/i;
+  const match = offenseText.match(districtPattern);
+
+  if (match) {
+    const district = match[1].trim();
+    const offense = offenseText.slice(0, match.index).trim();
+    return { offense, district };
+  }
+
+  return { offense: offenseText, district: null };
+}
+
+function parseDate(text: string): string | null {
+  const match = text.match(/(\w+)\s+(\d{1,2}),\s+(\d{4})/);
+  if (!match) return null;
+
+  const months: Record<string, string> = {
+    January: "01",
+    February: "02",
+    March: "03",
+    April: "04",
+    May: "05",
+    June: "06",
+    July: "07",
+    August: "08",
+    September: "09",
+    October: "10",
+    November: "11",
+    December: "12",
+  };
+
+  const month = months[match[1]];
+  if (!month) return null;
+
+  const day = match[2].padStart(2, "0");
+  return `${match[3]}-${month}-${day}`;
+}

--- a/src/lib/parsers/sentences.ts
+++ b/src/lib/parsers/sentences.ts
@@ -1,0 +1,135 @@
+/**
+ * Sentence parser - extracts structured data from clemency grant sentences
+ */
+
+export interface ParsedSentenceComponents {
+  sentence_in_months: number | null;
+  fine: number | null;
+  restitution: number | null;
+}
+
+/**
+ * Parse a sentence string and extract structured components
+ * Returns multiple parsed sentences for multi-count cases
+ */
+export function parseSentence(
+  sentenceText: string,
+): ParsedSentenceComponents[] {
+  if (!sentenceText) return [];
+
+  // Check for multi-count patterns (e.g., "1. ... 2. ...")
+  const countPattern = /(?:^|[;.]\s*)(\d+)\.\s+/g;
+  const matches: Array<{ index: number; length: number }> = [];
+  let match;
+
+  while ((match = countPattern.exec(sentenceText)) !== null) {
+    matches.push({ index: match.index, length: match[0].length });
+  }
+
+  const counts: string[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const startIdx = matches[i].index + matches[i].length;
+    const endIdx =
+      i + 1 < matches.length ? matches[i + 1].index : sentenceText.length;
+    counts.push(sentenceText.slice(startIdx, endIdx).trim());
+  }
+
+  // If no counts found, treat entire text as single sentence
+  if (counts.length === 0) {
+    counts.push(sentenceText);
+  }
+
+  return counts.map((countText) => parseSingleSentence(countText));
+}
+
+function parseSingleSentence(text: string): ParsedSentenceComponents {
+  return {
+    sentence_in_months: extractImprisonmentMonths(text),
+    fine: extractFine(text),
+    restitution: extractRestitution(text),
+  };
+}
+
+// --- Extraction helpers ---
+
+function extractImprisonmentMonths(text: string): number | null {
+  // Match patterns like "135 months' imprisonment" or "10 months imprisonment"
+  const monthMatch = text.match(/(\d+)\s*months?'?.*?\s*imprisonment/i);
+  if (monthMatch) {
+    return parseInt(monthMatch[1], 10);
+  }
+
+  // Match patterns like "10 years' imprisonment"
+  const yearMatch = text.match(/(\d+)\s*years?'?.*?\s*imprisonment/i);
+  if (yearMatch) {
+    return parseInt(yearMatch[1], 10) * 12;
+  }
+
+  // Handle written numbers
+  const writtenMatch = text.match(
+    /(one|two|three|four|five|six|seven|eight|nine|ten)\s+years?'?.*?\s*imprisonment/i,
+  );
+  if (writtenMatch) {
+    const wordToNum: Record<string, number> = {
+      one: 1,
+      two: 2,
+      three: 3,
+      four: 4,
+      five: 5,
+      six: 6,
+      seven: 7,
+      eight: 8,
+      nine: 9,
+      ten: 10,
+    };
+    const years = wordToNum[writtenMatch[1].toLowerCase()];
+    return years ? years * 12 : null;
+  }
+
+  return null;
+}
+
+function extractRestitution(text: string): number | null {
+  // Try specific restitution pattern first
+  const amount = extractDollarAmount(text, "restitution");
+  if (amount !== null) return amount;
+
+  // Try general dollar amount if "restitution" is mentioned nearby
+  const restitutionContext = text.match(/\$([\d,]+\.?\d*)[^;$]*restitution/i);
+  if (restitutionContext) {
+    const amountStr = restitutionContext[1].replace(/,/g, "");
+    const amount = parseFloat(amountStr);
+    return isNaN(amount) ? null : amount;
+  }
+
+  return null;
+}
+
+function extractFine(text: string): number | null {
+  const amount = extractDollarAmount(text, "fine");
+  if (amount !== null) return amount;
+
+  // Try general dollar amount if "fine" is mentioned nearby
+  const fineContext = text.match(/\$([\d,]+\.?\d*)[^;$]*fine/i);
+  if (fineContext) {
+    const amountStr = fineContext[1].replace(/,/g, "");
+    const amount = parseFloat(amountStr);
+    return isNaN(amount) ? null : amount;
+  }
+
+  return null;
+}
+
+function extractDollarAmount(text: string, keyword: string): number | null {
+  // Match patterns like "$36,769,153.97 restitution" or "$100,000,000 fine"
+  const pattern = new RegExp(`\\$([\\d,]+\\.?\\d*)\\s*(?:${keyword})`, "i");
+  const match = text.match(pattern);
+
+  if (match) {
+    const amountStr = match[1].replace(/,/g, "");
+    const amount = parseFloat(amountStr);
+    return isNaN(amount) ? null : amount;
+  }
+
+  return null;
+}

--- a/src/lib/parsers/table-five.ts
+++ b/src/lib/parsers/table-five.ts
@@ -1,0 +1,97 @@
+import * as cheerio from "cheerio";
+import type { ParsedGrant } from "./types.js";
+import { categorizeOffense } from "./categorize.js";
+
+/**
+ * Format B — Biden & Trump Term 1 (separate pardons/commutations pages).
+ *
+ * Structure:
+ * - <h2> headings with dates only
+ * - Tables with 5 columns: NAME | DISTRICT | SENTENCED | OFFENSE | PUBLIC DISCLOSURE
+ * - Warrant URL in PUBLIC DISCLOSURE column ("Download PDF Clemency Warrant" link)
+ * - Clemency type is known from the page URL (pardons vs commutations)
+ */
+export function parseTableFive(
+  html: string,
+  pardonType: "pardon" | "commutation",
+  sourceUrl: string,
+): ParsedGrant[] {
+  const $ = cheerio.load(html);
+  const grants: ParsedGrant[] = [];
+
+  const headings = $("h2");
+
+  headings.each((_i, heading) => {
+    const headingText = $(heading).text().trim();
+    const dateStr = parseDate(headingText);
+    if (!dateStr) return;
+
+    // Find the next table after this heading
+    const table = $(heading).nextAll("table").first();
+    if (!table.length) return;
+
+    const rows = table.find("tr").not(":has(th)");
+
+    rows.each((_rowIdx, row) => {
+      const cells = $(row).find("td");
+      if (cells.length < 4) return;
+
+      const name = cells.eq(0).text().trim();
+      if (!name) return;
+
+      // District might be missing on some entries (e.g., Hunter Biden)
+      const district = cells.eq(1).text().trim() || null;
+      const sentence = cells.eq(2).text().trim() || null;
+      const offense = cells.eq(3).text().trim();
+
+      // Warrant URL from PUBLIC DISCLOSURE column (5th column) or from name link
+      let warrantUrl: string | null = null;
+      if (cells.length >= 5) {
+        const disclosureLink = cells.eq(4).find("a");
+        if (disclosureLink.length) {
+          warrantUrl = disclosureLink.attr("href") || null;
+        }
+      }
+
+      grants.push({
+        recipient_name: name,
+        warrant_url: warrantUrl,
+        district,
+        sentence,
+        offense,
+        offense_category: categorizeOffense(offense),
+        pardon_type: pardonType,
+        grant_date: dateStr,
+        source_url: sourceUrl,
+      });
+    });
+  });
+
+  return grants;
+}
+
+function parseDate(text: string): string | null {
+  const match = text.match(/(\w+)\s+(\d{1,2}),\s+(\d{4})/);
+  if (!match) return null;
+
+  const months: Record<string, string> = {
+    January: "01",
+    February: "02",
+    March: "03",
+    April: "04",
+    May: "05",
+    June: "06",
+    July: "07",
+    August: "08",
+    September: "09",
+    October: "10",
+    November: "11",
+    December: "12",
+  };
+
+  const month = months[match[1]];
+  if (!month) return null;
+
+  const day = match[2].padStart(2, "0");
+  return `${match[3]}-${month}-${day}`;
+}

--- a/src/lib/parsers/table-four.ts
+++ b/src/lib/parsers/table-four.ts
@@ -1,0 +1,86 @@
+import * as cheerio from "cheerio";
+import type { ParsedGrant } from "./types.js";
+import { categorizeOffense } from "./categorize.js";
+
+/**
+ * Format C — Bush W. (separate pardons/commutations pages).
+ *
+ * Structure:
+ * - <h2> headings with dates
+ * - Tables with 4 columns: NAME | DISTRICT | SENTENCED | OFFENSE
+ * - No warrant links
+ * - Clemency type from URL
+ */
+export function parseTableFour(
+  html: string,
+  pardonType: "pardon" | "commutation",
+  sourceUrl: string,
+): ParsedGrant[] {
+  const $ = cheerio.load(html);
+  const grants: ParsedGrant[] = [];
+
+  const headings = $("h2");
+
+  headings.each((_i, heading) => {
+    const headingText = $(heading).text().trim();
+    const dateStr = parseDate(headingText);
+    if (!dateStr) return;
+
+    const table = $(heading).nextAll("table").first();
+    if (!table.length) return;
+
+    const rows = table.find("tr").not(":has(th)");
+
+    rows.each((_rowIdx, row) => {
+      const cells = $(row).find("td");
+      if (cells.length < 4) return;
+
+      const name = cells.eq(0).text().trim();
+      if (!name) return;
+
+      const district = cells.eq(1).text().trim() || null;
+      const sentence = cells.eq(2).text().trim() || null;
+      const offense = cells.eq(3).text().trim();
+
+      grants.push({
+        recipient_name: name,
+        warrant_url: null,
+        district,
+        sentence,
+        offense,
+        offense_category: categorizeOffense(offense),
+        pardon_type: pardonType,
+        grant_date: dateStr,
+        source_url: sourceUrl,
+      });
+    });
+  });
+
+  return grants;
+}
+
+function parseDate(text: string): string | null {
+  const match = text.match(/(\w+)\s+(\d{1,2}),\s+(\d{4})/);
+  if (!match) return null;
+
+  const months: Record<string, string> = {
+    January: "01",
+    February: "02",
+    March: "03",
+    April: "04",
+    May: "05",
+    June: "06",
+    July: "07",
+    August: "08",
+    September: "09",
+    October: "10",
+    November: "11",
+    December: "12",
+  };
+
+  const month = months[match[1]];
+  if (!month) return null;
+
+  const day = match[2].padStart(2, "0");
+  return `${match[3]}-${month}-${day}`;
+}

--- a/src/lib/parsers/trump2025.ts
+++ b/src/lib/parsers/trump2025.ts
@@ -1,0 +1,126 @@
+import * as cheerio from "cheerio";
+import type { ParsedGrant } from "./types.js";
+import { categorizeOffense } from "./categorize.js";
+
+/**
+ * Format A — Trump 2025 combined page.
+ *
+ * Structure:
+ * - <h3> headings with date + count + type, e.g.:
+ *   "January 21, 2025 - 1 Pardon"
+ *   "March 4, 2025 - 1 Commutation"
+ *   "May 28, 2025 - 16 Pardons and 6 Commutations"
+ * - Each <h3> is followed by a <table> with columns:
+ *   NAME and WARRANT | DISTRICT | SENTENCED | OFFENSE
+ * - Name cell links to warrant PDF
+ * - Skip headings whose next sibling is a <p> (links to external pages like J6)
+ */
+export function parseTrump2025(html: string, sourceUrl: string): ParsedGrant[] {
+  const $ = cheerio.load(html);
+  const grants: ParsedGrant[] = [];
+
+  const headings = $("h3");
+
+  headings.each((_i, heading) => {
+    const headingText = $(heading).text().trim();
+
+    // Skip headings without a date pattern
+    if (!/\w+ \d{1,2}, \d{4}/.test(headingText)) return;
+
+    // Find the next sibling — if it's not a table, skip (e.g., J6 or election links)
+    const nextSibling = $(heading).next();
+    if (!nextSibling.is("table")) return;
+
+    const table = nextSibling;
+    const dateStr = parseDate(headingText);
+    if (!dateStr) return;
+
+    const { pardonCount, commutationCount } = parseCounts(headingText);
+    const rows = table.find("tbody tr, tr").not(":has(th)");
+
+    rows.each((rowIdx, row) => {
+      const cells = $(row).find("td");
+      if (cells.length < 4) return;
+
+      const nameCell = cells.eq(0);
+      const name = nameCell.text().trim();
+      if (!name) return;
+
+      const link = nameCell.find("a");
+      const warrantUrl = link.length ? link.attr("href") || null : null;
+
+      const district = cells.eq(1).text().trim() || null;
+      const sentence = cells.eq(2).text().trim() || null;
+      const offense = cells.eq(3).text().trim();
+
+      // Determine clemency type from heading counts
+      let pardonType: "pardon" | "commutation";
+      if (commutationCount === 0) {
+        pardonType = "pardon";
+      } else if (pardonCount === 0) {
+        pardonType = "commutation";
+      } else {
+        // Mixed section: first N are pardons, rest are commutations
+        pardonType = rowIdx < pardonCount ? "pardon" : "commutation";
+      }
+
+      grants.push({
+        recipient_name: name,
+        warrant_url: warrantUrl,
+        district,
+        sentence,
+        offense,
+        offense_category: categorizeOffense(offense),
+        pardon_type: pardonType,
+        grant_date: dateStr,
+        source_url: sourceUrl,
+      });
+    });
+  });
+
+  return grants;
+}
+
+function parseDate(headingText: string): string | null {
+  const match = headingText.match(/(\w+)\s+(\d{1,2}),\s+(\d{4})/);
+  if (!match) return null;
+
+  const months: Record<string, string> = {
+    January: "01",
+    February: "02",
+    March: "03",
+    April: "04",
+    May: "05",
+    June: "06",
+    July: "07",
+    August: "08",
+    September: "09",
+    October: "10",
+    November: "11",
+    December: "12",
+  };
+
+  const month = months[match[1]];
+  if (!month) return null;
+
+  const day = match[2].padStart(2, "0");
+  return `${match[3]}-${month}-${day}`;
+}
+
+function parseCounts(heading: string): {
+  pardonCount: number;
+  commutationCount: number;
+} {
+  let pardonCount = 0;
+  let commutationCount = 0;
+
+  // Match patterns like "16 Pardons and 6 Commutations", "1 Pardon", "3 Commutations"
+  const pardonMatch = heading.match(/(\d+)\s+Pardons?/i);
+  const commutationMatch = heading.match(/(\d+)\s+Commutations?/i);
+
+  // Also match "(Amended)" suffix variants
+  if (pardonMatch) pardonCount = parseInt(pardonMatch[1], 10);
+  if (commutationMatch) commutationCount = parseInt(commutationMatch[1], 10);
+
+  return { pardonCount, commutationCount };
+}

--- a/src/lib/parsers/types.ts
+++ b/src/lib/parsers/types.ts
@@ -1,0 +1,41 @@
+export type OffenseCategory =
+  | "violent crime"
+  | "fraud"
+  | "drug offense"
+  | "FACE act"
+  | "immigration"
+  | "firearms"
+  | "financial crime"
+  | "other";
+
+export interface ParsedGrant {
+  recipient_name: string;
+  warrant_url: string | null;
+  district: string | null;
+  sentence: string | null;
+  offense: string;
+  offense_category: OffenseCategory;
+  pardon_type: "pardon" | "commutation";
+  grant_date: string;
+  source_url: string;
+}
+
+export type PageFormat =
+  | "trump2025"
+  | "table-five"
+  | "table-four"
+  | "key-value";
+
+export interface PresidentSource {
+  slugs: string[];
+  combined?: string;
+  pardons?: string;
+  commutations?: string;
+}
+
+export interface ParsedSentence {
+  sentence_in_months: number | null;
+  fine: number | null;
+  restitution: number | null;
+  original_sentence: string | null;
+}

--- a/src/loaders/pardon-details.ts
+++ b/src/loaders/pardon-details.ts
@@ -1,14 +1,15 @@
 import type { Loader } from "astro/loaders";
 import { z } from "astro/zod";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
+import { pardons, administrations } from "../db/schema";
+import { resolve } from "node:path";
 
-/**
- * Schema matching the pardon_details view as returned by PostgREST.
- */
 export const pardonDetailSchema = z.object({
-  id: z.string().uuid(),
-  administration_id: z.string().uuid(),
+  id: z.string(),
   administration_slug: z.string(),
-  grant_date: z.string(), // ISO date from PostgREST
+  grant_date: z.string(),
   clemency_type: z.enum(["pardon", "commutation"]),
   offense: z.string(),
   offense_category: z.enum([
@@ -39,28 +40,18 @@ export type PardonDetail = z.infer<typeof pardonDetailSchema>;
 
 interface PardonDetailsLoaderOptions {
   /**
-   * Override the API host URL (the /v1 base).
-   * Defaults to PARDONNED_API_HOST env var.
+   * Path to the SQLite database file.
+   * Resolved relative to process.cwd() (project root).
+   * Defaults to "data/pardonned.db".
    */
-  apiHost?: string;
+  dbPath?: string;
 
   /**
-   * Override the API key.
-   * Defaults to PARDONNED_API_KEY env var.
+   * Optional administration slug filter.
+   * When set, only pardons for that administration are loaded.
+   * Example: "trump-2"
    */
-  apiKey?: string;
-
-  /**
-   * The PostgREST resource path.
-   * Defaults to "pardon_details".
-   */
-  resource?: string;
-
-  /**
-   * Optional PostgREST query parameters for filtering.
-   * Example: { administration_slug: "eq.trump-2", offense_category: "eq.fraud" }
-   */
-  filters?: Record<string, string>;
+  administrationSlug?: string;
 }
 
 export function pardonDetailsLoader(
@@ -71,57 +62,65 @@ export function pardonDetailsLoader(
     schema: pardonDetailSchema,
 
     async load({ store, logger, parseData, generateDigest }) {
-      const apiHost = options.apiHost ?? import.meta.env.PARDONNED_API_HOST;
-      const apiKey = options.apiKey ?? import.meta.env.PARDONNED_API_KEY;
-      const resource = options.resource ?? "pardon_details";
+      const dbPath = resolve(
+        process.cwd(),
+        options.dbPath ?? "data/pardonned.db",
+      );
 
-      if (!apiHost || !apiKey) {
-        throw new Error(
-          "pardon-details-loader: missing PARDONNED_API_HOST or PARDONNED_API_KEY environment variables.",
-        );
-      }
+      logger.info(`Opening SQLite database at ${dbPath}`);
 
-      // Build URL with optional PostgREST filters
-      const url = new URL(`${apiHost}/${resource}`);
-      if (options.filters) {
-        for (const [key, value] of Object.entries(options.filters)) {
-          url.searchParams.set(key, value);
+      const sqlite = new Database(dbPath, { readonly: true });
+      const db = drizzle(sqlite);
+
+      try {
+        const query = db
+          .select({
+            id: pardons.id,
+            administration_slug: administrations.slug,
+            grant_date: pardons.grant_date,
+            clemency_type: pardons.clemency_type,
+            offense: pardons.offense,
+            offense_category: pardons.offense_category,
+            district: pardons.district,
+            warrant_url: pardons.warrant_url,
+            source_url: pardons.source_url,
+            recipient_name: pardons.recipient_name,
+            sentence_in_months: pardons.sentence_in_months,
+            fine: pardons.fine,
+            restitution: pardons.restitution,
+            original_sentence: pardons.original_sentence,
+            president_name: administrations.president_name,
+            term_number: administrations.term_number,
+            term_start_date: administrations.start_date,
+            term_end_date: administrations.end_date,
+          })
+          .from(pardons)
+          .innerJoin(
+            administrations,
+            eq(pardons.administration, administrations.id),
+          );
+
+        const rows = options.administrationSlug
+          ? query
+              .where(eq(administrations.slug, options.administrationSlug))
+              .all()
+          : query.all();
+
+        logger.info(`Read ${rows.length} rows from SQLite`);
+
+        store.clear();
+
+        for (const row of rows) {
+          const id = String(row.id);
+          const data = await parseData({ id, data: { ...row, id } });
+          const digest = generateDigest(data);
+          store.set({ id, data, digest });
         }
+
+        logger.info(`Stored ${rows.length} pardon detail entries`);
+      } finally {
+        sqlite.close();
       }
-
-      logger.info(`Fetching from ${url.toString()}`);
-
-      const response = await fetch(url.toString(), {
-        headers: {
-          apikey: apiKey,
-          Authorization: `Bearer ${apiKey}`,
-          "Accept-Profile": "pardonned",
-          Accept: "application/json",
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `pardon-details-loader: ${response.status} ${response.statusText} from ${url}`,
-        );
-      }
-
-      const rows: unknown[] = await response.json();
-      logger.info(`Received ${rows.length} rows`);
-
-      store.clear();
-
-      for (const row of rows) {
-        const raw = row as Record<string, unknown>;
-        const id = String(raw.id);
-
-        const data = await parseData({ id, data: raw });
-        const digest = generateDigest(data);
-
-        store.set({ id, data, digest });
-      }
-
-      logger.info(`Stored ${rows.length} pardon detail entries`);
     },
   } satisfies Loader;
 }


### PR DESCRIPTION
Add auto-detection of pardon table formats by inspecting HTML
structure to identify trump2025, table-five, table-four, and
key-value formats.

Migrate pardon-details loader from PostgREST API to local SQLite
database using better-sqlite3 and drizzle-orm. Replace API host
and key configuration with dbPath option for direct database
access. Simplify schema by removing UUID types and PostgREST
filter parameters.