### PR TITLE
president-filtering

### DIFF
--- a/src/components/FilterPill.astro
+++ b/src/components/FilterPill.astro
@@ -6,9 +6,10 @@ interface Props {
   href?: string;
   count?: number;
   'data-category'?: string;
+  'data-president'?: string;
 }
 
-const { label, active = false, onClick, href, count, 'data-category': dataCategory } = Astro.props;
+const { label, active = false, onClick, href, count, 'data-category': dataCategory, 'data-president': dataPresident } = Astro.props;
 
 const displayLabel = count !== undefined ? `${label} (${count})` : label;
 
@@ -27,6 +28,7 @@ const Element = href ? 'a' : 'button';
   type={!href ? 'button' : undefined}
   aria-pressed={active}
   data-category={dataCategory}
+  data-president={dataPresident}
 >
   {displayLabel}
 </Element>

--- a/src/components/StatGrid.astro
+++ b/src/components/StatGrid.astro
@@ -31,9 +31,10 @@ interface PardonStats {
 interface Props {
     stats: PardonStats;
     animated?: boolean;
+    footnote?: string;
 }
 
-const { stats, animated = false } = Astro.props;
+const { stats, animated = false, footnote } = Astro.props;
 ---
 
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-stat-grid">
@@ -42,7 +43,7 @@ const { stats, animated = false } = Astro.props;
         value={stats.totalGrants.toLocaleString()}
         variant="default"
         animated={animated}
-        footnote="Does not include January 6th"
+        footnote={footnote}
         animationDelay={animated ? 1 * 150 : 0}
     />
     <StatCard

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,6 +1,6 @@
 export const siteConfig = {
   name: "Pardonned",
-  tagline: "More Money..More Pardons?",
+  tagline: "Unofficial Pardon Tracker",
   description:
     "A public-interest site, tracking Presidential pardons since 2000",
   dataSource: "DOJ Office of the Pardon Attorney",

--- a/src/lib/__tests__/president-names.test.ts
+++ b/src/lib/__tests__/president-names.test.ts
@@ -83,6 +83,7 @@ describe("getAdministrationIndex", () => {
         administration_slug: "biden-1",
         president_name: "Joe Biden",
         term_number: 1,
+        term_start_date: "2021-01-20",
       },
     },
     {
@@ -90,6 +91,7 @@ describe("getAdministrationIndex", () => {
         administration_slug: "biden-1",
         president_name: "Joe Biden",
         term_number: 1,
+        term_start_date: "2021-01-20",
       },
     },
     {
@@ -97,6 +99,7 @@ describe("getAdministrationIndex", () => {
         administration_slug: "trump-1",
         president_name: "Donald Trump",
         term_number: 1,
+        term_start_date: "2017-01-20",
       },
     },
     {
@@ -104,6 +107,7 @@ describe("getAdministrationIndex", () => {
         administration_slug: "trump-2",
         president_name: "Donald Trump",
         term_number: 2,
+        term_start_date: "2025-01-20",
       },
     },
     {
@@ -111,6 +115,7 @@ describe("getAdministrationIndex", () => {
         administration_slug: "trump-2",
         president_name: "Donald Trump",
         term_number: 2,
+        term_start_date: "2025-01-20",
       },
     },
     {
@@ -118,6 +123,7 @@ describe("getAdministrationIndex", () => {
         administration_slug: "trump-2",
         president_name: "Donald Trump",
         term_number: 2,
+        term_start_date: "2025-01-20",
       },
     },
   ];
@@ -156,6 +162,13 @@ describe("getAdministrationIndex", () => {
     expect(trump2.presidentName).toBe("Donald Trump");
     expect(trump2.termNumber).toBe(2);
     expect(trump2.slug).toBe("trump-2");
+  });
+
+  it("carries termStartDate from the first matching entry", () => {
+    const index = getAdministrationIndex(fixture);
+    expect(index.get("biden-1")!.termStartDate).toBe("2021-01-20");
+    expect(index.get("trump-1")!.termStartDate).toBe("2017-01-20");
+    expect(index.get("trump-2")!.termStartDate).toBe("2025-01-20");
   });
 
   it("returns an empty map for an empty collection", () => {

--- a/src/lib/president-names.ts
+++ b/src/lib/president-names.ts
@@ -37,6 +37,7 @@ export interface AdministrationIndexEntry {
   displayName: string;
   presidentName: string;
   termNumber: number;
+  termStartDate: string;
   count: number;
 }
 
@@ -54,6 +55,7 @@ export interface AdministrationIndexInput {
     administration_slug: string;
     president_name: string;
     term_number: number;
+    term_start_date: string;
   };
 }
 
@@ -105,6 +107,7 @@ export function getAdministrationIndex(
       }),
       presidentName: president_name,
       termNumber: term_number,
+      termStartDate: entry.data.term_start_date,
       count: 1,
     });
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import StatGrid from "../components/StatGrid.astro";
-import CategoryGrid from "../components/CategoryGrid.astro";
-import Timeline from "../components/Timeline.astro";
 import SourceBanner from "../components/SourceBanner.astro";
 import "../styles/global.css";
 
@@ -10,98 +8,29 @@ const currentPath = Astro.url.pathname;
 
 import { getCollection } from "astro:content";
 import { computeStats } from "../lib/pardon-stats";
-import { slugify } from "../lib/slugify";
-
-const categoryColors: Record<string, string> = {
-    fraud: "#8A6B1E",
-    "drug offense": "#3A6A4A",
-    firearms: "#C23B22",
-    "FACE act": "#B8652A",
-    "financial crime": "#2A6A7A",
-    "violent crime": "#6A4B7A",
-    immigration: "#7A6A3A",
-    other: "#7A7870",
-};
+import { getAdministrationIndex } from "../lib/president-names";
 
 const allGrants = await getCollection("pardonDetails");
 const stats = computeStats(allGrants);
-
-const categoryCounts = Object.entries(stats.byCategory).map(([key, count]) => ({
-    key,
-    name: key.replace(/\b\w/g, (c) => c.toUpperCase()),
-    count,
-    color: categoryColors[key] ?? "#7A7880",
-}));
-
-const groupedByDate = allGrants.reduce(
-    (acc, entry) => {
-        const date = entry.data.grant_date;
-        if (!acc[date]) acc[date] = [];
-        acc[date].push(entry.data);
-        return acc;
-    },
-    {} as Record<string, (typeof allGrants)[number]["data"][]>,
+const index = getAdministrationIndex(allGrants);
+const sortedAdmins = Array.from(index.values()).sort((a, b) =>
+    b.termStartDate.localeCompare(a.termStartDate),
 );
-
-const sortedDates = Object.keys(groupedByDate).sort((a, b) =>
-    b.localeCompare(a),
-);
-
-const timelineEntries = sortedDates.map((date, i) => {
-    const grants = groupedByDate[date];
-    const names = grants.map((g) => g.recipient_name);
-    const categories = [...new Set(grants.map((g) => g.offense_category))];
-    const pardons = grants.filter((g) => g.clemency_type === "pardon").length;
-    const commutations = grants.filter(
-        (g) => g.clemency_type === "commutation",
-    ).length;
-
-    // Create hrefs mapping for each name
-    const hrefs = grants.reduce((acc, grant) => {
-        acc[grant.recipient_name] = `/pardon/details/${slugify(grant.recipient_name)}`;
-        return acc;
-    }, {} as Record<string, string>);
-
-    const parts: string[] = [];
-    if (pardons > 0)
-        parts.push(`${pardons} ${pardons === 1 ? "pardon" : "pardons"}`);
-    if (commutations > 0)
-        parts.push(
-            `${commutations} ${commutations === 1 ? "commutation" : "commutations"}`,
-        );
-
-    const grantLabel = parts.join(", ");
-    const [y, m, d] = date.split("-");
-    const formattedDate = new Date(
-        Number(y),
-        Number(m) - 1,
-        Number(d),
-    ).toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-    });
-
-    return {
-        date: formattedDate,
-        grants: grantLabel,
-        names,
-        highlight: categories.join(", "),
-        isLatest: i === 0,
-        hrefs,
-    };
-});
 ---
 
-<Layout title="Home" description="Explore presidential clemency grants. Track pardons and commutations by category, date, and financial impact." ogImage="/og/home.png" currentPath={currentPath}>
+<Layout
+    title="Home"
+    description="Explore presidential clemency grants. Track pardons and commutations across administrations by category, date, and financial impact."
+    ogImage="/og/home.png"
+    currentPath={currentPath}
+>
     <!-- Hero Section -->
     <section class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center">
         <h1 class="hero-headline mb-6 max-w-3xl mx-auto">
-            Pardons granted by Donald J Trump
+            Tracking Presidential Pardons
         </h1>
-        <h2 class="hero-subtitle mb-8">Not Including the January 6th Pardons</h2>
+        <h2 class="hero-subtitle mb-8">Since 2000</h2>
         <StatGrid stats={stats} animated={true} />
-        <p class="hero-tracking pt-4 mb-0">Updated April 2026</p>
     </section>
 
     <!-- Gradient Divider -->
@@ -109,19 +38,28 @@ const timelineEntries = sortedDates.map((date, i) => {
         <div class="divider-gradient"></div>
     </div>
 
-    <!-- Categories Section -->
+    <!-- Administrations Section -->
     <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
         <h2 class="text-section font-serif text-text-primary mb-2">
-            By Offense Category
+            By Administration
         </h2>
         <p class="text-nav text-text-faint mb-10">
-            Breakdown of all pardons by type of offense
+            Select an administration to explore its clemency record
         </p>
-        <CategoryGrid
-            categoryCounts={categoryCounts}
-            columns={3}
-            hrefPattern="/search?category={key}"
-        />
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-grid">
+            {sortedAdmins.map((admin) => (
+                <a
+                    href={`/president/${admin.slug}`}
+                    class="category-card hover:bg-muted transition-colors"
+                    style="border-left-color: var(--color-accent);"
+                >
+                    <span class="category-count" style="color: var(--color-accent);">
+                        {admin.count.toLocaleString()}
+                    </span>
+                    <span class="text-nav text-text-body">{admin.displayName}</span>
+                </a>
+            ))}
+        </div>
     </section>
 
     <!-- Flat Divider -->
@@ -129,19 +67,17 @@ const timelineEntries = sortedDates.map((date, i) => {
         <div class="divider-flat"></div>
     </div>
 
-    <!-- Timeline Section -->
-    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
-        <h2 class="text-section font-serif text-text-primary mb-2">Timeline</h2>
-        <p class="text-nav text-text-faint mb-10">
-            Every clemency action in reverse chronological order
+    <!-- Search CTA -->
+    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto text-center" data-animate>
+        <h2 class="text-section font-serif text-text-primary mb-4">
+            Explore the Data
+        </h2>
+        <p class="text-nav text-text-faint mb-8">
+            Search, filter, and explore all {stats.totalGrants.toLocaleString()} clemency grants
         </p>
-        <Timeline entries={timelineEntries} />
-
-        <div class="text-center mt-5">
-            <a href="/search" class="load-more-btn inline-block no-underline">
-                Search all pardons →
-            </a>
-        </div>
+        <a href="/search" class="load-more-btn inline-block no-underline">
+            Search all pardons →
+        </a>
     </section>
 
     <!-- Source Banner -->
@@ -154,15 +90,12 @@ const timelineEntries = sortedDates.map((date, i) => {
 
 <script is:inline>
   document.addEventListener('DOMContentLoaded', () => {
-    // Track category card clicks via event delegation (href contains ?category=key)
-    document.querySelector('.grid')?.addEventListener('click', (e) => {
-      const card = e.target.closest('a[href*="category="]');
-      if (!card) return;
-      const url = new URL(card.href, window.location.origin);
-      const category = url.searchParams.get('category');
-      if (category) {
-        window.posthog?.capture('category_clicked', { category });
-      }
+    // Track administration card clicks
+    document.querySelectorAll('a[href^="/president/"]').forEach((card) => {
+      card.addEventListener('click', () => {
+        const slug = card.getAttribute('href')?.replace('/president/', '');
+        window.posthog?.capture('administration_clicked', { slug });
+      });
     });
 
     // Track "Search all pardons" CTA click

--- a/src/pages/og/home.png.ts
+++ b/src/pages/og/home.png.ts
@@ -10,10 +10,10 @@ export const GET: APIRoute = async () => {
   const stats = computeStats(allGrants);
 
   const png = await renderOgImage({
-    title: "Tracking the Pardons granted by Donald J Trump",
-    subtitle: "More Money, More Pardons ",
+    title: "Tracking Presidential Pardons",
+    subtitle: "More Money, More Pardons",
     stat: `${stats.totalGrants}`,
-    statLabel: "Pardons Granted (not including January 6th)",
+    statLabel: "Clemency Grants Tracked",
   });
 
   return new Response(png as unknown as BodyInit, {

--- a/src/pages/og/president/[slug].png.ts
+++ b/src/pages/og/president/[slug].png.ts
@@ -1,6 +1,9 @@
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
-import { computeStats, filterByAdministration } from "../../../lib/pardon-stats";
+import {
+  computeStats,
+  filterByAdministration,
+} from "../../../lib/pardon-stats";
 import { getAdministrationIndex } from "../../../lib/president-names";
 import { renderOgImage } from "../../../lib/og-image";
 

--- a/src/pages/og/president/[slug].png.ts
+++ b/src/pages/og/president/[slug].png.ts
@@ -1,0 +1,34 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import { computeStats, filterByAdministration } from "../../../lib/pardon-stats";
+import { getAdministrationIndex } from "../../../lib/president-names";
+import { renderOgImage } from "../../../lib/og-image";
+
+export const prerender = true;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const allGrants = await getCollection("pardonDetails");
+  const index = getAdministrationIndex(allGrants);
+  return Array.from(index.values()).map((admin) => ({
+    params: { slug: admin.slug },
+    props: { admin },
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const { admin } = props;
+  const allGrants = await getCollection("pardonDetails");
+  const filtered = filterByAdministration(allGrants, admin.slug);
+  const stats = computeStats(filtered);
+
+  const png = await renderOgImage({
+    title: `Pardons granted by ${admin.displayName}`,
+    subtitle: "More Money, More Pardons",
+    stat: `${stats.totalGrants}`,
+    statLabel: "Clemency Grants",
+  });
+
+  return new Response(png as unknown as BodyInit, {
+    headers: { "Content-Type": "image/png" },
+  });
+};

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -1,0 +1,215 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import StatGrid from "../../components/StatGrid.astro";
+import CategoryGrid from "../../components/CategoryGrid.astro";
+import Timeline from "../../components/Timeline.astro";
+import SourceBanner from "../../components/SourceBanner.astro";
+import FilterPill from "../../components/FilterPill.astro";
+import "../../styles/global.css";
+
+import { getCollection } from "astro:content";
+import { computeStats, filterByAdministration } from "../../lib/pardon-stats";
+import { getAdministrationIndex } from "../../lib/president-names";
+import { slugify } from "../../lib/slugify";
+
+const categoryColors: Record<string, string> = {
+    fraud: "#8A6B1E",
+    "drug offense": "#3A6A4A",
+    firearms: "#C23B22",
+    "FACE act": "#B8652A",
+    "financial crime": "#2A6A7A",
+    "violent crime": "#6A4B7A",
+    immigration: "#7A6A3A",
+    other: "#7A7870",
+};
+
+export async function getStaticPaths() {
+    const allGrants = await getCollection("pardonDetails");
+    const index = getAdministrationIndex(allGrants);
+    const sortedAdmins = Array.from(index.values()).sort((a, b) =>
+        b.termStartDate.localeCompare(a.termStartDate),
+    );
+
+    return sortedAdmins.map((admin) => ({
+        params: { slug: admin.slug },
+        props: {
+            admin,
+            entries: filterByAdministration(allGrants, admin.slug),
+            allAdmins: sortedAdmins,
+        },
+    }));
+}
+
+const { admin, entries, allAdmins } = Astro.props;
+const stats = computeStats(entries);
+
+const categoryCounts = Object.entries(stats.byCategory).map(([key, count]) => ({
+    key,
+    name: key.replace(/\b\w/g, (c) => c.toUpperCase()),
+    count,
+    color: categoryColors[key] ?? "#7A7880",
+}));
+
+const groupedByDate = entries.reduce(
+    (acc, entry) => {
+        const date = entry.data.grant_date;
+        if (!acc[date]) acc[date] = [];
+        acc[date].push(entry.data);
+        return acc;
+    },
+    {} as Record<string, (typeof entries)[number]["data"][]>,
+);
+
+const sortedDates = Object.keys(groupedByDate).sort((a, b) =>
+    b.localeCompare(a),
+);
+
+const timelineEntries = sortedDates.map((date, i) => {
+    const grants = groupedByDate[date];
+    const names = grants.map((g) => g.recipient_name);
+    const categories = [...new Set(grants.map((g) => g.offense_category))];
+    const pardons = grants.filter((g) => g.clemency_type === "pardon").length;
+    const commutations = grants.filter(
+        (g) => g.clemency_type === "commutation",
+    ).length;
+
+    const hrefs = grants.reduce(
+        (acc, grant) => {
+            acc[grant.recipient_name] =
+                `/pardon/details/${slugify(grant.recipient_name)}`;
+            return acc;
+        },
+        {} as Record<string, string>,
+    );
+
+    const parts: string[] = [];
+    if (pardons > 0)
+        parts.push(`${pardons} ${pardons === 1 ? "pardon" : "pardons"}`);
+    if (commutations > 0)
+        parts.push(
+            `${commutations} ${commutations === 1 ? "commutation" : "commutations"}`,
+        );
+
+    const grantLabel = parts.join(", ");
+    const [y, m, d] = date.split("-");
+    const formattedDate = new Date(
+        Number(y),
+        Number(m) - 1,
+        Number(d),
+    ).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    });
+
+    return {
+        date: formattedDate,
+        grants: grantLabel,
+        names,
+        highlight: categories.join(", "),
+        isLatest: i === 0,
+        hrefs,
+    };
+});
+
+const isTrump = admin.slug.startsWith("trump-");
+const footnote = isTrump ? "Does not include January 6th" : undefined;
+---
+
+<Layout
+    title={admin.displayName}
+    description={`Clemency grants by ${admin.displayName}. Track pardons and commutations by category, date, and financial impact.`}
+    ogImage={`/og/president/${admin.slug}.png`}
+    currentPath={`/president/${admin.slug}`}
+>
+    <!-- President Navigation Pills -->
+    <nav class="max-w-home mx-auto px-5 md:px-10 pt-8 pb-2">
+        <div class="flex flex-wrap gap-2">
+            <FilterPill label="All" href="/" />
+            {allAdmins.map((a) => (
+                <FilterPill
+                    label={a.displayName}
+                    count={a.count}
+                    href={`/president/${a.slug}`}
+                    active={a.slug === admin.slug}
+                />
+            ))}
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center">
+        <h1 class="hero-headline mb-6 max-w-3xl mx-auto">
+            Pardons granted by {admin.displayName}
+        </h1>
+        {isTrump && (
+            <h2 class="hero-subtitle mb-8">Not Including the January 6th Pardons</h2>
+        )}
+        <StatGrid stats={stats} animated={true} footnote={footnote} />
+    </section>
+
+    <!-- Gradient Divider -->
+    <div class="max-w-home mx-auto px-5 md:px-10">
+        <div class="divider-gradient"></div>
+    </div>
+
+    <!-- Categories Section -->
+    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
+        <h2 class="text-section font-serif text-text-primary mb-2">
+            By Offense Category
+        </h2>
+        <p class="text-nav text-text-faint mb-10">
+            Breakdown of all pardons by type of offense
+        </p>
+        <CategoryGrid
+            categoryCounts={categoryCounts}
+            columns={3}
+            hrefPattern={`/search?president=${admin.slug}&category={key}`}
+        />
+    </section>
+
+    <!-- Flat Divider -->
+    <div class="max-w-home mx-auto px-5 md:px-10">
+        <div class="divider-flat"></div>
+    </div>
+
+    <!-- Timeline Section -->
+    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
+        <h2 class="text-section font-serif text-text-primary mb-2">Timeline</h2>
+        <p class="text-nav text-text-faint mb-10">
+            Every clemency action in reverse chronological order
+        </p>
+        <Timeline entries={timelineEntries} />
+
+        <div class="text-center mt-5">
+            <a href={`/search?president=${admin.slug}`} class="load-more-btn inline-block no-underline">
+                Search all pardons →
+            </a>
+        </div>
+    </section>
+
+    <!-- Source Banner -->
+    <section class="max-w-source mx-auto px-5 md:px-8 mb-10">
+        <SourceBanner />
+    </section>
+</Layout>
+
+<script src="/scripts/animate-on-scroll.js" is:inline></script>
+
+<script is:inline>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelector('.grid')?.addEventListener('click', (e) => {
+      const card = e.target.closest('a[href*="category="]');
+      if (!card) return;
+      const url = new URL(card.href, window.location.origin);
+      const category = url.searchParams.get('category');
+      if (category) {
+        window.posthog?.capture('category_clicked', { category, source: 'president_page' });
+      }
+    });
+
+    document.querySelector('a[href*="/search"].load-more-btn')?.addEventListener('click', () => {
+      window.posthog?.capture('search_all_pardons_clicked', { source: 'president_page' });
+    });
+  });
+</script>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -5,10 +5,15 @@ import '../styles/global.css';
 
 import { getCollection } from "astro:content";
 import { slugify } from "../lib/slugify";
+import { getAdministrationIndex } from "../lib/president-names";
 
 const currentPath = Astro.url.pathname;
 
 const allGrants = await getCollection("pardonDetails");
+const administrationIndex = getAdministrationIndex(allGrants);
+const sortedAdmins = Array.from(administrationIndex.values()).sort((a, b) =>
+    b.termStartDate.localeCompare(a.termStartDate),
+);
 
 const categoryColors: Record<string, string> = {
     fraud: "#8A6B1E",
@@ -57,6 +62,7 @@ const searchResults = allGrants.map((entry) => {
         date: formatDate(d.grant_date),
         restitution: d.restitution ?? 0,
         fine: d.fine ?? 0,
+        administrationSlug: d.administration_slug,
     };
 });
 
@@ -104,6 +110,18 @@ for (const grant of searchResults) {
       </div>
     </div>
 
+    <!-- President Pills -->
+    <div id="president-pills" class="flex flex-wrap gap-2 mb-4">
+        <FilterPill label="All Presidents" active={true} count={searchResults.length} data-president="all" />
+        {sortedAdmins.map((admin) => (
+            <FilterPill
+                label={admin.displayName}
+                count={admin.count}
+                data-president={admin.slug}
+            />
+        ))}
+    </div>
+
     <!-- Category Pills -->
     <div id="category-pills" class="flex flex-wrap gap-2 mb-8">
       <FilterPill label="All" active={true} count={searchResults.length} data-category="all" />
@@ -144,6 +162,7 @@ for (const grant of searchResults) {
       const categoryPills = document.getElementById('category-pills');
 
       let activeCategory = 'all';
+      let activePresident = 'all';
 
       function formatRestitution(value) {
         if (value >= 1000000) return `$${(value / 1000000).toFixed(1)}M`;
@@ -284,14 +303,16 @@ for (const grant of searchResults) {
           const matchesSearch = !searchTerm || grant.name.toLowerCase().includes(searchTerm) || grant.offense.toLowerCase().includes(searchTerm);
           const matchesType = !typeFilter || grant.clemencyType === typeFilter;
           const matchesCategory = activeCategory === 'all' || grant.category === activeCategory;
-          return matchesSearch && matchesType && matchesCategory;
+          const matchesPresident = activePresident === 'all' || grant.administrationSlug === activePresident;
+          return matchesSearch && matchesType && matchesCategory && matchesPresident;
         });
 
         renderResults(filtered);
       }
 
-      function setActivePill(pill) {
-        document.querySelectorAll('#category-pills button, #category-pills a').forEach((p) => {
+      function setActivePill(pill, containerId) {
+        const container = document.getElementById(containerId);
+        container.querySelectorAll('button, a').forEach((p) => {
           p.classList.remove('filter-pill-active');
           p.classList.add('filter-pill-inactive');
         });
@@ -324,9 +345,20 @@ for (const grant of searchResults) {
         if (!pill) return;
 
         activeCategory = pill.dataset.category || 'all';
-        setActivePill(pill);
+        setActivePill(pill, 'category-pills');
         filterGrants();
         window.posthog?.capture('category_filter_applied', { category: activeCategory });
+      });
+
+      const presidentPills = document.getElementById('president-pills');
+      presidentPills.addEventListener('click', (e) => {
+        const pill = e.target.closest('button, a');
+        if (!pill) return;
+
+        activePresident = pill.dataset.president || 'all';
+        setActivePill(pill, 'president-pills');
+        filterGrants();
+        window.posthog?.capture('president_filter_applied', { president: activePresident });
       });
 
       // Track search result clicks
@@ -337,14 +369,24 @@ for (const grant of searchResults) {
         window.posthog?.capture('search_result_clicked', { slug });
       });
 
-      // Apply ?category= URL param as initial filter (from home page links)
+      // Apply URL params as initial filters
       const urlParams = new URLSearchParams(window.location.search);
+
+      const initialPresident = urlParams.get('president');
+      if (initialPresident) {
+        const matchingPill = presidentPills.querySelector(`[data-president="${initialPresident}"]`);
+        if (matchingPill) {
+          activePresident = initialPresident;
+          setActivePill(matchingPill, 'president-pills');
+        }
+      }
+
       const initialCategory = urlParams.get('category');
       if (initialCategory) {
         const matchingPill = categoryPills.querySelector(`[data-category="${initialCategory}"]`);
         if (matchingPill) {
           activeCategory = initialCategory;
-          setActivePill(matchingPill);
+          setActivePill(matchingPill, 'category-pills');
         }
       }
 


### PR DESCRIPTION
# Important Changes

- Added `termStartDate` to administration index entry
- FilterPill now accepts `data-president` prop and StatGrid footnote is configurable
- Created per-president static pages at `/president/[slug]`
- Transformed home page into multi-president overview landing
- Added per-president OG images and neutral home OG image
- Added president filter to search page

Closes #6 and #7