### PR TITLE
fix/table-four-header-skip

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,5 +7,6 @@
   "rules": {},
   "env": {
     "builtin": true
-  }
+  },
+  "ignorePatterns": ["src/components/PostHog.astro"]
 }

--- a/docs/superpowers/plans/2026-04-10-db-backed-slugs.md
+++ b/docs/superpowers/plans/2026-04-10-db-backed-slugs.md
@@ -1,0 +1,1152 @@
+# DB-Backed Pardon Slugs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move pardon slug generation from build-time JS (`src/lib/slugify.ts` called from every consuming page) into a single post-scrape pass that writes a unique, collision-resolved slug into a new `pardons.slug` column. The content collection loader exposes that column directly, so all pages read `grant.data.slug` instead of recomputing. Fixes both a parser bug that's been producing garbage "NAME"/"DISTRICT"/"SENTENCED"/"OFFENSE" rows on the Obama pages and the long-standing ~33-page gap between DB row count and built page count caused by silent `getStaticPaths` dedup on collision.
+
+**Architecture:** Three small additions + one column. A defensive `name !== "NAME"` check in the two `<td>`-vs-`<th>` parsers (`table-four.ts`, `table-five.ts`) stops the garbage rows at the source. A new pure function `assignSlugs(rows)` in `src/lib/slug-assigner.ts` takes a deterministic `id ASC` pass over every pardon, calls the existing `slugify(name)` to get a base slug (which still respects the manual override map), and walks an escalation chain `base → base-date → base-date-type → base-id` on collision, so row-1-wins-the-clean-slug. A wrapper `assignAllPardonSlugs()` in `src/lib/db.ts` runs that function against all rows and writes back in a single transaction. `scrape.ts` calls it once after all presidents are scraped. The loader exposes `slug` on every entry. Pages drop their `slugify()` imports and read `grant.data.slug` directly.
+
+**Tech Stack:** TypeScript, Drizzle ORM, SQLite, vitest 4, Astro 6 content collections, cheerio. No new dependencies.
+
+**Related issues:** Closes #12, closes #13. Uncovers and fixes an Obama-parser bug as a precondition.
+
+---
+
+## Context
+
+GitHub issue #13 reported that the build log showed ~30 pardons "missing" from `dist/` because Astro's `getStaticPaths` silently dedupes when two entries produce the same `slug` param. Issue #12 proposed moving slug generation out of the pages and into the DB via a "rules engine" at scrape time, so slugs can be unique-constrained at the schema level. Both were filed as separate issues but the #13 body explicitly notes that "this work pairs naturally with #12" — a DB-backed slug column solves both problems in one pass.
+
+Before writing this plan, a one-off investigation script ran `slugify()` over every row in `data/pardonned.db` and enumerated collision clusters. Findings:
+
+- **Total pardons:** 2,349 (grown from 2,149 at the time #13 was filed).
+- **Distinct slugs:** 2,316. Rows lost to dedup: **33**.
+- **Of those 33 lost rows, ~16 are literal parser garbage**, not a slug problem. Four slug clusters — `name`, `district`, `sentenced`, `offense` — each contain **5 rows** where the `recipient_name` value is literally the string `"NAME"`, `"DISTRICT"`, `"SENTENCED"`, or `"OFFENSE"`. All 20 come from `obama-1` and `obama-2`. They are table-header rows scraped as if they were pardon records.
+
+The parser bug is in both `src/lib/parsers/table-four.ts:32` and `src/lib/parsers/table-five.ts:34`:
+
+```ts
+const rows = table.find("tr").not(":has(th)");
+```
+
+This filter is supposed to skip header rows by excluding any `<tr>` that contains a `<th>` element. But if the DOJ HTML uses `<td>` for some header rows instead (which it does on the Obama pages for at least 5 dated sub-tables), the filter misses them entirely and the loop parses them as pardon records. Defensive fix: after extracting the name cell, check whether it equals `"NAME"` (case-insensitive) and skip.
+
+That accounts for 16 of the 33 missing pages. The remaining 17 clusters are genuine data collisions and break down into three categories:
+
+1. **Admin-scoped near-duplicates (trump-2):** Three rows (Julio M. Herrera Velutini, Mark T. Rossini, Wanda Vazquez Garced) are each listed twice 5 days apart (2026-01-15 + 2026-01-20), almost certainly a DOJ prelim list followed by the final list. Imaad Shah Zuberi listed 5 months apart (2025-05-28 + 2025-10-01).
+2. **Real within-admin double events (trump-1):** The Hammonds (Dwight + Steven) received simultaneous `pardon` + `commutation` on 2018-07-10. Alice Marie Johnson received a 2018 commutation and a 2020 pardon. Judith Negron / Crystal Munoz / Tynice Nichole Hall each received a Feb 18 2020 commutation followed by a Dec 22 2020 commutation (the well-known Trump-1 clemency list that was expanded). These are historically distinct events that deserve distinct pages.
+3. **Cross-administration name matches:** Joseph Schwartz, Connie Avalos, Scottie Ladon Dixon, Michael Anthony Tedesco, Jose Alonso Compean — each has rows under two different presidents. May or may not be the same person; domain call.
+4. **One data-quality oddity:** `brittany-krambeck` collides with `brittany-krambeck*` (asterisk, biden-1, different grant dates) — probably a DOJ footnote marker scraped as part of the name. Out of scope for this plan; would need parser work on the asterisk handling.
+
+### Slug collision resolution: first-wins + escalation chain
+
+Per user decision: first row by `id ASC` keeps the clean base slug; subsequent colliding rows escalate through `base-date → base-date-type → base-id`. Examples of the resulting URLs:
+
+- `/pardon/details/alice-marie-johnson` → 2018 commutation (row #645, earliest id)
+- `/pardon/details/alice-marie-johnson-2020-08-28` → 2020 pardon (row #527 — wait, lower id wins, so #527 keeps `alice-marie-johnson`; this example gets rewritten in the verification step once we know the real id order)
+- `/pardon/details/dwight-lincoln-hammond` → pardon (row #505)
+- `/pardon/details/dwight-lincoln-hammond-2018-07-10-commutation` → commutation (row #646, same date so `-date` collides, escalates to `-date-type`)
+
+The `base-id` fallback is mathematically guaranteed to succeed (ids are unique), so the escalation chain is total. The `MAX_SLUG_LENGTH = 60` cap still applies to the `base` computed by `slugify()`, but collision-resolved slugs may exceed 60 characters. That is acceptable — the filesystem limit is 255 bytes and the readability-60 design was for the common case, not for the rare collision case where the extra characters carry meaningful disambiguation.
+
+### Why this stays inside one plan instead of splitting into two
+
+The parser fix (tasks 1–2) could technically ship as a standalone PR without touching slugs, but doing so would require inventing a separate schema-change plan for #12/#13 that still has to grapple with 17 leftover real collisions — a smaller version of the same work. Bundling them means one plan, one PR, one re-scrape, and one verification pass. The blast radius is small: 4 parser test additions, 2 parser source edits (1 line each), 1 new file (`slug-assigner.ts` + tests), 1 column added to the schema, 1 wrapper function in `db.ts`, 1 loader update, 5 page edits to drop `slugify()` calls.
+
+### What stays, what goes
+
+- **Stays:** `src/lib/slugify.ts` (used by the new `slug-assigner.ts` as the base-slug producer), `src/lib/pardon-slug-overrides.ts` (still consulted by `slugify()` — the override map is the editorial-slug layer and has no replacement), and `src/lib/__tests__/slugify.test.ts` (no changes — `slugify()` itself is unchanged).
+- **Goes:** Every `import { slugify } from ".../slugify"` in a page file (4 files), and every call to `slugify(something.recipient_name)` in page code. Pages read `grant.data.slug` instead.
+
+## File Structure
+
+### Create
+
+- `src/lib/parsers/__tests__/table-four.test.ts` — vitest tests for the defensive header-row skip (first parser test file in the project)
+- `src/lib/parsers/__tests__/table-five.test.ts` — same
+- `src/lib/slug-assigner.ts` — pure function `assignSlugs(rows): Map<number, string>` implementing the first-wins escalation chain
+- `src/lib/__tests__/slug-assigner.test.ts` — unit tests for the assigner, using inline fixtures (no DB)
+
+### Modify
+
+- `src/lib/parsers/table-four.ts:36` — add `if (name.toUpperCase() === "NAME") return;` defensive filter
+- `src/lib/parsers/table-five.ts:40` — same defensive filter
+- `src/db/schema.ts:19-66` — add `slug: text("slug").unique()` to the `pardons` table definition
+- `src/lib/db.ts:12-43` — add `slug TEXT` to the `CREATE TABLE pardons` DDL + add a `CREATE UNIQUE INDEX` statement; add an in-place `PRAGMA table_info` migration step after the DDL executes so existing local DBs get the column without needing a full re-scrape
+- `src/lib/db.ts` (bottom) — add `assignAllPardonSlugs()` export that queries `id, recipient_name, grant_date, clemency_type` from every pardon row, calls `assignSlugs()`, and writes the result back in a single transaction
+- `src/scraper/scrape.ts:100-104` — after the `for (const source of sources)` loop completes, call `await assignAllPardonSlugs()` so the post-pass runs once per full scrape
+- `src/loaders/pardon-details.ts:9-37` — add `slug: z.string()` to the zod schema, add `slug: pardons.slug` to the `.select()` projection
+- `src/pages/pardon/details/[slug].astro:6, 14, 182, 192` — remove the `slugify` import, replace `slugify(grant.data.recipient_name)` in `getStaticPaths` with `grant.data.slug`, replace the two other call sites in the frontmatter with `data.slug`
+- `src/pages/og/[slug].png.ts:3, 32` — remove `slugify` import, replace the `getStaticPaths` call with `d.slug`
+- `src/pages/search.astro:6, 58` — remove `slugify` import, replace `slugify(d.recipient_name)` with `d.slug`
+- `src/pages/president/[slug].astro:13, 79` — remove `slugify` import, replace `slugify(grant.recipient_name)` with `grant.slug`
+
+### Delete
+
+Nothing. `src/lib/slugify.ts` and `src/lib/pardon-slug-overrides.ts` both remain — they're still used by the new `slug-assigner.ts` to produce the base slug for each row.
+
+## Worktree Preconditions
+
+Work in `.worktrees/db-backed-slugs/` per project convention (CLAUDE.md gotcha). Symlink `data/` from the main checkout (`ln -sf ../../data data`) so the scrape step in task 8 can reuse an existing DB instead of scraping from scratch mid-task. Full re-scrape happens once, as the final verification step.
+
+---
+
+## Task 1: Fix parseTableFour to skip `<td>`-based header rows
+
+**Files:**
+- Create: `src/lib/parsers/__tests__/table-four.test.ts`
+- Modify: `src/lib/parsers/table-four.ts:36`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/parsers/__tests__/table-four.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseTableFour } from "../table-four";
+
+describe("parseTableFour", () => {
+  it("parses a normal 4-column pardon row", () => {
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFour(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+  });
+
+  it("skips header rows that use <td> instead of <th>", () => {
+    // Obama-era DOJ HTML sometimes uses <td> for headers in later tables
+    // on the same page. The :has(th) filter misses these; a content-based
+    // check against the sentinel "NAME" value must catch them.
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td></tr>
+        </table>
+        <h2>March 1, 2013</h2>
+        <table>
+          <tr><td>NAME</td><td>DISTRICT</td><td>SENTENCED</td><td>OFFENSE</td></tr>
+          <tr><td>John Smith</td><td>W.D. Tex.</td><td>12 months</td><td>Theft</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFour(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(2);
+    expect(grants.map((g) => g.recipient_name)).toEqual(["Jane Doe", "John Smith"]);
+    expect(grants.map((g) => g.recipient_name)).not.toContain("NAME");
+  });
+
+  it("skips header rows regardless of case", () => {
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><td>name</td><td>district</td><td>sentenced</td><td>offense</td></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFour(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/lib/parsers/__tests__/table-four.test.ts`
+Expected: the first test (`parses a normal 4-column pardon row`) passes. The second test fails with a length-2-vs-3 mismatch — the header row sneaks through and is parsed as a pardon named "NAME". The third test (lowercase) also fails.
+
+- [ ] **Step 3: Add the defensive filter**
+
+Edit `src/lib/parsers/table-four.ts`. In the `rows.each` callback, immediately after `if (!name) return;`, add:
+
+```ts
+// Defensive: skip header rows that use <td> instead of <th>. Obama-era
+// DOJ HTML is inconsistent — the first table on a page often has proper
+// <th> headers (caught by the :has(th) filter above), but later tables
+// on the same page reuse <td> for their header rows and slip through.
+if (name.toUpperCase() === "NAME") return;
+```
+
+Exact edit context:
+
+```ts
+      const name = cells.eq(0).text().trim();
+      if (!name) return;
+      if (name.toUpperCase() === "NAME") return;
+
+      const district = cells.eq(1).text().trim() || null;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/lib/parsers/__tests__/table-four.test.ts`
+Expected: all three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but add src/lib/parsers/table-four.ts src/lib/parsers/__tests__/table-four.test.ts
+but commit -m "fix(parser): skip <td>-based header rows in table-four
+
+The Obama DOJ pages contain sub-tables whose header rows use <td>
+instead of <th>, slipping past the :has(th) filter and producing 5
+garbage pardon records per Obama page with recipient_name values
+like 'NAME', 'DISTRICT', 'SENTENCED', 'OFFENSE'. Add a content-based
+check against the sentinel 'NAME' value to catch them.
+
+Closes the parser half of #13."
+```
+
+---
+
+## Task 2: Fix parseTableFive to skip `<td>`-based header rows
+
+**Files:**
+- Create: `src/lib/parsers/__tests__/table-five.test.ts`
+- Modify: `src/lib/parsers/table-five.ts:40`
+
+Same bug shape as table-four. No known incidents in the current data (table-five is used for Biden and Trump Term 1, neither of which has garbage rows today), but the fix is cheap and prevents the same class of regression if the DOJ pages drift.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/parsers/__tests__/table-five.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseTableFive } from "../table-five";
+
+describe("parseTableFive", () => {
+  it("parses a normal 5-column pardon row with warrant link", () => {
+    const html = `
+      <html><body>
+        <h2>December 22, 2020</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th><th>PUBLIC DISCLOSURE</th></tr>
+          <tr>
+            <td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td>
+            <td><a href="/pardon/file/123/dl">Download PDF Clemency Warrant</a></td>
+          </tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFive(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+    expect(grants[0].warrant_url).toContain("/pardon/file/123/dl");
+  });
+
+  it("skips header rows that use <td> instead of <th>", () => {
+    const html = `
+      <html><body>
+        <h2>December 22, 2020</h2>
+        <table>
+          <tr><td>NAME</td><td>DISTRICT</td><td>SENTENCED</td><td>OFFENSE</td><td>PUBLIC DISCLOSURE</td></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td><td></td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFive(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/lib/parsers/__tests__/table-five.test.ts`
+Expected: first test passes, second test fails (2 grants instead of 1).
+
+- [ ] **Step 3: Add the defensive filter**
+
+Edit `src/lib/parsers/table-five.ts`. In the `rows.each` callback, immediately after `if (!name) return;`, add:
+
+```ts
+if (name.toUpperCase() === "NAME") return;
+```
+
+Exact edit context:
+
+```ts
+      const name = cells.eq(0).text().trim();
+      if (!name) return;
+      if (name.toUpperCase() === "NAME") return;
+
+      // District might be missing on some entries (e.g., Hunter Biden)
+      const district = cells.eq(1).text().trim() || null;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/lib/parsers/__tests__/table-five.test.ts`
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but add src/lib/parsers/table-five.ts src/lib/parsers/__tests__/table-five.test.ts
+but commit -m "fix(parser): skip <td>-based header rows in table-five
+
+Apply the same defensive content check used in table-four. No known
+incidents in the current Biden/Trump-1 data, but prevents the same
+regression class if the DOJ pages drift."
+```
+
+---
+
+## Task 3: Add `slug` column to the pardons schema
+
+**Files:**
+- Modify: `src/db/schema.ts:19-66`
+- Modify: `src/lib/db.ts:12-43, ~333`
+
+This task does not add any assignment logic — just the column and the migration. Rows will be inserted with a null slug until task 5 wires up the assigner.
+
+- [ ] **Step 1: Add slug to the drizzle schema**
+
+Edit `src/db/schema.ts`. In the `pardons` table definition, add a new column between `recipient_name` and `clemency_type`:
+
+```ts
+export const pardons = sqliteTable(
+  "pardons",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    administration: integer("administration")
+      .notNull()
+      .references(() => administrations.id),
+    recipient_name: text("recipient_name").notNull(),
+    slug: text("slug").unique(),
+    clemency_type: text("clemency_type", {
+      enum: ["pardon", "commutation"],
+    }).notNull(),
+    // ... rest unchanged
+```
+
+Note: `.unique()` without `.notNull()` because rows are inserted with a null slug and the assigner pass fills them in afterward. SQLite's UNIQUE treats NULLs as distinct, so multiple pending-null rows coexist cleanly during scrape; once the assigner writes back, every row has a non-null unique slug.
+
+- [ ] **Step 2: Update the DDL in db.ts**
+
+Edit `src/lib/db.ts`. Update the `DDL` constant string (lines 12–43) — add `slug TEXT,` after `recipient_name TEXT NOT NULL,` and add a `CREATE UNIQUE INDEX` after the table definition:
+
+```ts
+const DDL = `
+CREATE TABLE IF NOT EXISTS administrations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT UNIQUE NOT NULL,
+  president_name TEXT NOT NULL,
+  term_number INTEGER NOT NULL,
+  start_date TEXT NOT NULL,
+  end_date TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS pardons (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  administration INTEGER NOT NULL REFERENCES administrations(id),
+  recipient_name TEXT NOT NULL,
+  slug TEXT,
+  clemency_type TEXT NOT NULL CHECK(clemency_type IN ('pardon','commutation')),
+  grant_date TEXT NOT NULL,
+  warrant_url TEXT,
+  source_url TEXT,
+  district TEXT,
+  offense TEXT NOT NULL,
+  offense_category TEXT NOT NULL CHECK(offense_category IN ('violent crime','fraud','drug offense','FACE act','immigration','firearms','financial crime','other')),
+  sentence_in_months INTEGER,
+  fine REAL,
+  restitution REAL,
+  original_sentence TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(administration, recipient_name, grant_date, clemency_type)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS pardons_slug_unique ON pardons(slug);
+`;
+```
+
+- [ ] **Step 3: Add in-place migration for existing DBs**
+
+Still in `src/lib/db.ts`, find the line `await client.executeMultiple(DDL);` (around line 333) and replace that single line with:
+
+```ts
+await client.executeMultiple(DDL);
+
+// In-place migration: ALTER existing DBs that predate the slug column.
+// SQLite's CREATE TABLE IF NOT EXISTS won't add columns to an existing
+// table, so we check for the column via PRAGMA and ALTER if missing.
+// Partial index is handled by the CREATE UNIQUE INDEX IF NOT EXISTS in DDL.
+{
+  const cols = await client.execute("PRAGMA table_info(pardons)");
+  const hasSlug = cols.rows.some((r) => r.name === "slug");
+  if (!hasSlug) {
+    await client.execute("ALTER TABLE pardons ADD COLUMN slug TEXT");
+    await client.execute(
+      "CREATE UNIQUE INDEX IF NOT EXISTS pardons_slug_unique ON pardons(slug)",
+    );
+    console.log("Migrated: added pardons.slug column");
+  }
+}
+```
+
+- [ ] **Step 4: Smoke-test the migration on an existing DB**
+
+Run in the worktree with its existing symlinked data/:
+
+```bash
+pnpm tsx -e "import('./src/lib/db.js').then(() => import('@libsql/client').then(async ({ createClient }) => { const c = createClient({ url: 'file:./data/pardonned.db' }); const r = await c.execute('PRAGMA table_info(pardons)'); console.log(r.rows.map(x => x.name).join(', ')); c.close(); }))"
+```
+
+Expected: column list includes `slug`. If not, inspect the migration output for errors.
+
+Alternative manual check:
+
+```bash
+sqlite3 data/pardonned.db "PRAGMA table_info(pardons);" | grep slug
+```
+
+Expected output: a line containing `slug|TEXT`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but add src/db/schema.ts src/lib/db.ts
+but commit -m "feat(db): add pardons.slug column with in-place migration
+
+Nullable TEXT column with a unique index. Nullable so that rows can
+be inserted first and have their slugs computed by a post-scrape
+pass in a later commit — SQLite's UNIQUE treats NULLs as distinct,
+so multiple pending-null rows coexist during the scrape window.
+
+Existing local DBs are migrated in place via a PRAGMA table_info
+check before ALTER TABLE. Fresh DBs get the column via the updated
+CREATE TABLE DDL. CI always starts from a fresh DB so the migration
+path is only exercised locally.
+
+Preparation for #12/#13."
+```
+
+---
+
+## Task 4: Implement `assignSlugs` as a pure function with full test coverage
+
+**Files:**
+- Create: `src/lib/slug-assigner.ts`
+- Create: `src/lib/__tests__/slug-assigner.test.ts`
+
+The assigner takes an array of minimal row records (id, recipient_name, grant_date, clemency_type) and returns a `Map<number, string>` from row id to final unique slug. The function is pure — no DB access, no side effects — so it's fully unit-testable with inline fixtures and reusable from anywhere.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/__tests__/slug-assigner.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { assignSlugs, type AssignerRow } from "../slug-assigner";
+
+function row(
+  id: number,
+  name: string,
+  grant_date = "2020-01-01",
+  clemency_type: "pardon" | "commutation" = "pardon",
+): AssignerRow {
+  return { id, recipient_name: name, grant_date, clemency_type };
+}
+
+describe("assignSlugs", () => {
+  describe("no collisions", () => {
+    it("assigns the base slug to a single row", () => {
+      const result = assignSlugs([row(1, "Jane Smith")]);
+      expect(result.get(1)).toBe("jane-smith");
+    });
+
+    it("assigns distinct base slugs to rows with distinct names", () => {
+      const result = assignSlugs([row(1, "Jane Smith"), row(2, "John Doe")]);
+      expect(result.get(1)).toBe("jane-smith");
+      expect(result.get(2)).toBe("john-doe");
+    });
+  });
+
+  describe("first-wins collision: two rows, same name, different dates", () => {
+    it("first id keeps the base slug; second gets -date suffix", () => {
+      const rows = [
+        row(1, "Alice Marie Johnson", "2018-06-06", "commutation"),
+        row(2, "Alice Marie Johnson", "2020-08-28", "pardon"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("alice-marie-johnson");
+      expect(result.get(2)).toBe("alice-marie-johnson-2020-08-28");
+    });
+
+    it("first-wins is determined by id, not input order", () => {
+      // Deliberately reverse-order the input
+      const rows = [
+        row(2, "Alice Marie Johnson", "2020-08-28", "pardon"),
+        row(1, "Alice Marie Johnson", "2018-06-06", "commutation"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("alice-marie-johnson");
+      expect(result.get(2)).toBe("alice-marie-johnson-2020-08-28");
+    });
+  });
+
+  describe("escalation: same name AND same date", () => {
+    it("escalates to -date-type when -date collides (Hammonds case)", () => {
+      // Same person, same day, pardon + commutation
+      const rows = [
+        row(1, "Dwight Lincoln Hammond", "2018-07-10", "pardon"),
+        row(2, "Dwight Lincoln Hammond", "2018-07-10", "commutation"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("dwight-lincoln-hammond");
+      expect(result.get(2)).toBe("dwight-lincoln-hammond-2018-07-10-commutation");
+    });
+  });
+
+  describe("fallback: everything collides", () => {
+    it("uses -id suffix as the final fallback", () => {
+      // Three rows with identical name + date + type: unreachable IRL
+      // but the algorithm must still produce unique slugs.
+      const rows = [
+        row(1, "Jane Doe", "2020-01-01", "pardon"),
+        row(2, "Jane Doe", "2020-01-01", "pardon"),
+        row(3, "Jane Doe", "2020-01-01", "pardon"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("jane-doe");
+      // Row 2's base collides, -date collides (2020-01-01), -date-type
+      // collides (jane-doe-2020-01-01-pardon), so it falls through to -id.
+      expect(result.get(2)).toBe("jane-doe-2");
+      expect(result.get(3)).toBe("jane-doe-3");
+    });
+  });
+
+  describe("respects slugify() overrides for the base slug", () => {
+    it("applies the Jan 6 Committee override as the base for a unique row", () => {
+      const jan6Name =
+        "The Members of Congress who served on the Select Committee to Investigate the January 6th Attack on the United States Capitol (\u201CSelect Committee\u201D); the staff of the Select Committee, as provided by House Resolution 503 (117th Congress); and the police officers from the D.C. Metropolitan Police Department or the U.S. Capitol Police who testified before the Select Committee";
+      const result = assignSlugs([row(1, jan6Name, "2025-01-19", "pardon")]);
+      expect(result.get(1)).toBe("january-6th-committee");
+    });
+  });
+
+  describe("determinism", () => {
+    it("produces identical output for identical input", () => {
+      const rows = [
+        row(1, "Alice", "2020-01-01", "pardon"),
+        row(2, "Alice", "2021-01-01", "pardon"),
+        row(3, "Bob", "2020-01-01", "pardon"),
+      ];
+      const a = assignSlugs(rows);
+      const b = assignSlugs(rows);
+      expect([...a.entries()].sort()).toEqual([...b.entries()].sort());
+    });
+  });
+
+  describe("every row gets a unique slug", () => {
+    it("post-condition: result size equals input size, all values distinct", () => {
+      const rows = [
+        row(1, "Alice", "2020-01-01", "pardon"),
+        row(2, "Alice", "2020-01-01", "commutation"),
+        row(3, "Alice", "2021-01-01", "pardon"),
+        row(4, "Bob"),
+        row(5, "Carol"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.size).toBe(rows.length);
+      const slugs = [...result.values()];
+      expect(new Set(slugs).size).toBe(slugs.length);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/lib/__tests__/slug-assigner.test.ts`
+Expected: all tests fail with `Cannot find module '../slug-assigner'`.
+
+- [ ] **Step 3: Implement the assigner**
+
+Create `src/lib/slug-assigner.ts`:
+
+```ts
+import { slugify } from "./slugify";
+
+export interface AssignerRow {
+  id: number;
+  recipient_name: string;
+  grant_date: string;
+  clemency_type: "pardon" | "commutation";
+}
+
+/**
+ * Assign a unique URL slug to every pardon row.
+ *
+ * Algorithm: deterministic pass in ascending `id` order. For each row,
+ * compute a base slug via `slugify(recipient_name)` (which consults the
+ * manual override map in `pardon-slug-overrides.ts` before falling back
+ * to the normalize-and-hash algorithm). Then walk a four-step escalation
+ * chain and claim the first candidate not already taken:
+ *
+ *   1. base
+ *   2. base-<grant_date>
+ *   3. base-<grant_date>-<clemency_type>
+ *   4. base-<id>   (guaranteed unique because ids are unique)
+ *
+ * The first-wins ordering is intentional: the row with the smallest id
+ * (typically the earliest-scraped one) keeps the clean base slug. Later
+ * colliding rows carry the disambiguation information in their URL.
+ *
+ * Returns a `Map<id, slug>`. The caller is responsible for writing the
+ * slugs back to the database; this function is pure so it can be tested
+ * without a DB.
+ */
+export function assignSlugs(rows: AssignerRow[]): Map<number, string> {
+  const sorted = [...rows].sort((a, b) => a.id - b.id);
+  const taken = new Set<string>();
+  const result = new Map<number, string>();
+
+  for (const row of sorted) {
+    const base = slugify(row.recipient_name);
+    const candidates = [
+      base,
+      `${base}-${row.grant_date}`,
+      `${base}-${row.grant_date}-${row.clemency_type}`,
+      `${base}-${row.id}`,
+    ];
+    for (const candidate of candidates) {
+      if (!taken.has(candidate)) {
+        taken.add(candidate);
+        result.set(row.id, candidate);
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/lib/__tests__/slug-assigner.test.ts`
+Expected: all 10 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but add src/lib/slug-assigner.ts src/lib/__tests__/slug-assigner.test.ts
+but commit -m "feat(slugs): add pure assignSlugs collision resolver
+
+First-wins by id. Escalation chain: base → base-date → base-date-type
+→ base-id. The -id fallback is mathematically guaranteed to succeed
+because ids are unique, so the algorithm is total.
+
+Pure function with 10 unit tests covering: unique case, first-wins
+by id (including reverse input order), date escalation, type
+escalation for the Hammonds-style same-day pardon+commutation, -id
+fallback, override-map respect for the Jan 6 Committee case, and
+post-conditions (determinism, every row gets a distinct slug).
+
+Preparation for #12/#13."
+```
+
+---
+
+## Task 5: Wire `assignAllPardonSlugs` into the scraper post-pass
+
+**Files:**
+- Modify: `src/lib/db.ts` (add `assignAllPardonSlugs` export)
+- Modify: `src/scraper/scrape.ts:93-105`
+
+- [ ] **Step 1: Add assignAllPardonSlugs to db.ts**
+
+Edit `src/lib/db.ts`. At the bottom of the file, after `upsertGrants`, add:
+
+```ts
+import { assignSlugs } from "./slug-assigner.js";
+
+export async function assignAllPardonSlugs(): Promise<{
+  assigned: number;
+  collisionsResolved: number;
+}> {
+  const rows = await db
+    .select({
+      id: pardons.id,
+      recipient_name: pardons.recipient_name,
+      grant_date: pardons.grant_date,
+      clemency_type: pardons.clemency_type,
+    })
+    .from(pardons)
+    .all();
+
+  const slugMap = assignSlugs(rows);
+
+  // Count how many rows got anything other than a pure base slug — useful
+  // as a scrape-log signal to notice regressions in the collision count.
+  let collisionsResolved = 0;
+  for (const row of rows) {
+    const assigned = slugMap.get(row.id);
+    // A row's slug differs from its "clean" form iff collision escalation
+    // kicked in. We can't easily recompute the base here without duplicating
+    // slugify, so instead we count rows whose final slug contains a date
+    // or id suffix. This is a rough signal, not a proof.
+    if (assigned && /-\d{4}-\d{2}-\d{2}/.test(assigned)) {
+      collisionsResolved += 1;
+    }
+  }
+
+  // Write back in one transaction. Drizzle's libsql driver runs these as
+  // individual UPDATE statements inside a transaction; for ~2,500 rows
+  // this is fast enough (sub-second on an M-series Mac).
+  await db.transaction(async (tx) => {
+    for (const [id, slug] of slugMap) {
+      await tx.update(pardons).set({ slug }).where(eq(pardons.id, id)).run();
+    }
+  });
+
+  return { assigned: slugMap.size, collisionsResolved };
+}
+```
+
+Note: the existing `src/lib/db.ts` already imports `eq` from `drizzle-orm` (line 4) and `pardons` from `../db/schema.js` (line 6), so those imports are already present. The only new import is `assignSlugs`.
+
+- [ ] **Step 2: Call it from the scraper entry point**
+
+Edit `src/scraper/scrape.ts`. At the top, add the import:
+
+```ts
+import { upsertGrants, assignAllPardonSlugs } from "../lib/db.js";
+```
+
+(replacing the existing `import { upsertGrants } from "../lib/db.js";` at line 3).
+
+Then in the `main()` function, after the `await scrapePresident(...)` call but before the `finally` block, add the slug-assignment step. Find the section:
+
+```ts
+  try {
+    if (presidentFilter === "all" || !presidentFilter) {
+      console.log("Scraping all configured presidents...");
+      await scrapePresident();
+    } else {
+      await scrapePresident(presidentFilter);
+    }
+  } finally {
+    await closeBrowser();
+  }
+```
+
+Change it to:
+
+```ts
+  try {
+    if (presidentFilter === "all" || !presidentFilter) {
+      console.log("Scraping all configured presidents...");
+      await scrapePresident();
+    } else {
+      await scrapePresident(presidentFilter);
+    }
+
+    console.log("\nAssigning slugs...");
+    const { assigned, collisionsResolved } = await assignAllPardonSlugs();
+    console.log(`  Assigned ${assigned} slugs (${collisionsResolved} collision-resolved)`);
+  } finally {
+    await closeBrowser();
+  }
+```
+
+The assigner runs after all presidents, even when only one is scraped — this is necessary because single-president scrapes can still introduce rows whose names collide with pre-existing rows in the DB from earlier scrapes.
+
+- [ ] **Step 3: Smoke-test on the existing DB**
+
+Run the assigner by itself to verify it works against the current `data/pardonned.db` (which already has the slug column from task 3):
+
+```bash
+pnpm tsx -e "import { assignAllPardonSlugs } from './src/lib/db.js'; const r = await assignAllPardonSlugs(); console.log(r);"
+```
+
+Expected output: `{ assigned: 2349, collisionsResolved: <some number, likely 17 or so> }`.
+
+Then check that every row has a slug:
+
+```bash
+sqlite3 data/pardonned.db "SELECT COUNT(*) FROM pardons WHERE slug IS NULL;"
+```
+
+Expected: `0`.
+
+And check for duplicates:
+
+```bash
+sqlite3 data/pardonned.db "SELECT slug, COUNT(*) c FROM pardons GROUP BY slug HAVING c > 1;"
+```
+
+Expected: no rows (the UNIQUE index would have rejected duplicates anyway, but this is the direct check).
+
+- [ ] **Step 4: Commit**
+
+```bash
+but add src/lib/db.ts src/scraper/scrape.ts
+but commit -m "feat(scraper): assign slugs in a post-scrape pass
+
+Adds assignAllPardonSlugs() which loads every row, runs them through
+the pure assignSlugs() resolver, and writes back in one transaction.
+Called once from scrape.ts after all presidents are scraped so it
+sees the complete dataset when resolving collisions.
+
+Logs an 'assigned N slugs (M collision-resolved)' summary line. The
+collision count is approximate (regex matches date-suffixed slugs)
+but useful as a smoke signal to notice parser or data regressions.
+
+Closes #12 (storage layer)."
+```
+
+---
+
+## Task 6: Expose `slug` through the content collection loader
+
+**Files:**
+- Modify: `src/loaders/pardon-details.ts:9-37, 71-93`
+
+- [ ] **Step 1: Add slug to the zod schema**
+
+Edit `src/loaders/pardon-details.ts`. In `pardonDetailSchema`, add `slug: z.string()` between `id` and `administration_slug`:
+
+```ts
+export const pardonDetailSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  administration_slug: z.string(),
+  grant_date: z.string(),
+  // ... rest unchanged
+```
+
+- [ ] **Step 2: Add slug to the DB projection**
+
+In the same file, in the `.select({...})` call, add `slug: pardons.slug` between `id` and `administration_slug`:
+
+```ts
+        const query = db
+          .select({
+            id: pardons.id,
+            slug: pardons.slug,
+            administration_slug: administrations.slug,
+            grant_date: pardons.grant_date,
+            // ... rest unchanged
+```
+
+- [ ] **Step 3: Quick sanity check (no test file yet — verified end-to-end in task 8)**
+
+There's no existing unit-test file for the loader, and adding one just for this column is overkill given task 8 does a full build. Instead, run a one-off check:
+
+```bash
+pnpm tsx -e "import { pardonDetailsLoader } from './src/loaders/pardon-details.js'; const loader = pardonDetailsLoader(); const store = new Map(); await loader.load({ store: { set: (e) => store.set(e.id, e), clear: () => store.clear() }, logger: console, parseData: async ({ data }) => data, generateDigest: () => 'x' }); const first = [...store.values()][0]; console.log('slug:', first.data.slug, 'name:', first.data.recipient_name);"
+```
+
+Expected: a slug value is printed alongside the recipient name. If zod complains about `slug` being required but missing, the DB column hasn't been populated — re-run task 5's smoke step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+but add src/loaders/pardon-details.ts
+but commit -m "feat(loader): expose pardons.slug on content collection entries
+
+Adds the slug field to the zod schema and the Drizzle SELECT
+projection. Downstream pages read grant.data.slug instead of
+calling slugify() at build time."
+```
+
+---
+
+## Task 7: Replace `slugify()` calls in page files with `grant.data.slug`
+
+**Files:**
+- Modify: `src/pages/pardon/details/[slug].astro:6, 14, 182, 192`
+- Modify: `src/pages/og/[slug].png.ts:3, 32`
+- Modify: `src/pages/search.astro:6, 58`
+- Modify: `src/pages/president/[slug].astro:13, 79`
+
+All four changes follow the same pattern: remove the `slugify` import, replace each `slugify(...recipient_name)` call with the corresponding `.slug` field from the loaded data.
+
+- [ ] **Step 1: Update pardon/details/[slug].astro**
+
+Edit `src/pages/pardon/details/[slug].astro`.
+
+Remove line 6:
+```ts
+import { slugify } from "../../../lib/slugify";
+```
+
+Replace line 14 (inside `getStaticPaths`):
+```ts
+        params: { slug: slugify(grant.data.recipient_name) },
+```
+with:
+```ts
+        params: { slug: grant.data.slug },
+```
+
+Replace line 182 (inside the breadcrumbs JSON-LD):
+```ts
+{ name: data.recipient_name, url: `https://pardonned.com/pardon/details/${slugify(data.recipient_name)}` },
+```
+with:
+```ts
+{ name: data.recipient_name, url: `https://pardonned.com/pardon/details/${data.slug}` },
+```
+
+Replace line 192 (OG image path):
+```ts
+const ogImagePath = `/og/${slugify(data.recipient_name)}.png`;
+```
+with:
+```ts
+const ogImagePath = `/og/${data.slug}.png`;
+```
+
+- [ ] **Step 2: Update og/[slug].png.ts**
+
+Edit `src/pages/og/[slug].png.ts`.
+
+Remove line 3:
+```ts
+import { slugify } from "../../lib/slugify";
+```
+
+Replace line 32 (inside `getStaticPaths`):
+```ts
+      params: { slug: slugify(d.recipient_name) },
+```
+with:
+```ts
+      params: { slug: d.slug },
+```
+
+- [ ] **Step 3: Update search.astro**
+
+Edit `src/pages/search.astro`.
+
+Remove line 6:
+```ts
+import { slugify } from "../lib/slugify";
+```
+
+Replace line 58 (inside the `searchResults` map):
+```ts
+        slug: slugify(d.recipient_name),
+```
+with:
+```ts
+        slug: d.slug,
+```
+
+- [ ] **Step 4: Update president/[slug].astro**
+
+Edit `src/pages/president/[slug].astro`.
+
+Remove line 13:
+```ts
+import { slugify } from "../../lib/slugify";
+```
+
+Replace line 79 (inside the grant href template):
+```ts
+                `/pardon/details/${slugify(grant.recipient_name)}`;
+```
+with:
+```ts
+                `/pardon/details/${grant.slug}`;
+```
+
+- [ ] **Step 5: Verify no remaining callers outside the slug layer**
+
+Search for any remaining imports of `slugify` in page or component code. Use ripgrep (or the equivalent Grep tool in your runner):
+
+```bash
+rg -n "from ['\"].*slugify['\"]" src/
+```
+
+Expected output: exactly two matches — `src/lib/slug-assigner.ts` (the base-slug producer) and `src/lib/__tests__/slugify.test.ts` (the existing unit tests). Any other match is a missed call site; return to the relevant sub-step above and finish the replacement before continuing.
+
+- [ ] **Step 6: Build to verify all four pages compile**
+
+Run: `pnpm build`
+Expected: build succeeds. The dist output should contain roughly 2,329 pages (2,349 − 20 header rows), subject to the task 8 re-scrape.
+
+- [ ] **Step 7: Commit**
+
+```bash
+but add src/pages/pardon/details/[slug].astro src/pages/og/[slug].png.ts src/pages/search.astro src/pages/president/[slug].astro
+but commit -m "refactor(pages): read grant.data.slug instead of slugify()
+
+All four page consumers now read the pre-computed slug from the
+content collection entry rather than recomputing at build time.
+slugify.ts and pardon-slug-overrides.ts both remain because
+slug-assigner.ts still uses slugify() as the base-slug producer.
+
+Closes #13."
+```
+
+---
+
+## Task 8: Full re-scrape and end-to-end verification
+
+**Files:** No files modified — this task is verification only.
+
+- [ ] **Step 1: Fresh-scrape the DB**
+
+```bash
+rm data/pardonned.db
+pnpm scrape
+```
+
+Expected runtime: 5–10 minutes. Watch for the "Assigning slugs... Assigned N slugs (M collision-resolved)" line near the end. N should be around **2,329** (2,349 minus 20 header rows stopped by the parser fix). M should be around **17–20** (the real collision clusters, each contributing 1+ resolved rows).
+
+- [ ] **Step 2: Verify row count**
+
+```bash
+sqlite3 data/pardonned.db "SELECT COUNT(*) FROM pardons;"
+```
+
+Expected: a number around 2,329. If it's still 2,349, the parser fix didn't apply — check tasks 1 and 2 were committed and re-run the scrape.
+
+- [ ] **Step 3: Verify no null slugs**
+
+```bash
+sqlite3 data/pardonned.db "SELECT COUNT(*) FROM pardons WHERE slug IS NULL;"
+```
+
+Expected: `0`. Non-zero means the assigner didn't run, or it skipped rows.
+
+- [ ] **Step 4: Verify all slugs are unique**
+
+```bash
+sqlite3 data/pardonned.db "SELECT slug, COUNT(*) c FROM pardons GROUP BY slug HAVING c > 1;"
+```
+
+Expected: no rows. (The UNIQUE index would reject inserts/updates that violate this, but a direct read is a good sanity check.)
+
+- [ ] **Step 5: Verify no garbage slugs**
+
+```bash
+sqlite3 data/pardonned.db "SELECT id, slug, recipient_name FROM pardons WHERE slug IN ('name', 'district', 'sentenced', 'offense');"
+```
+
+Expected: no rows. If any appear, the parser fix didn't catch them — investigate the row's `recipient_name` and confirm it matches the filter.
+
+- [ ] **Step 6: Verify expected collision-resolved slugs exist**
+
+```bash
+sqlite3 data/pardonned.db "SELECT id, slug, recipient_name, grant_date, clemency_type FROM pardons WHERE slug LIKE 'alice-marie-johnson%' ORDER BY id;"
+```
+
+Expected: two rows, one with slug `alice-marie-johnson` (lower id, first-wins) and one with a date-suffixed slug.
+
+```bash
+sqlite3 data/pardonned.db "SELECT id, slug, recipient_name, grant_date, clemency_type FROM pardons WHERE slug LIKE 'dwight-lincoln-hammond%' ORDER BY id;"
+```
+
+Expected: two rows, one with slug `dwight-lincoln-hammond` and one with slug `dwight-lincoln-hammond-2018-07-10-commutation` (the `-date-type` escalation because both rows share the same date).
+
+- [ ] **Step 7: Build the site and verify page count matches row count**
+
+```bash
+pnpm build
+```
+
+Expected: build completes. The final log line reports "N page(s) built in Xs" — N should equal the pardon row count from step 2 (around 2,329) plus the other non-pardon pages (home, search, OG images, president pages, sitemap, etc.). The detailed pardon page count should match exactly: run
+
+```bash
+find dist/pardon/details -maxdepth 1 -type d | wc -l
+```
+
+and compare to the DB count. They should differ by 1 (for the `details` directory itself).
+
+- [ ] **Step 8: Spot-check two specific URLs from the collision set**
+
+Open `dist/pardon/details/alice-marie-johnson/index.html` and confirm it's a real, rendered page with the correct recipient name. Then open `dist/pardon/details/dwight-lincoln-hammond-2018-07-10-commutation/index.html` and confirm the same. Neither should be a 404 / missing file.
+
+- [ ] **Step 9: Confirm garbage routes do NOT exist**
+
+```bash
+ls dist/pardon/details/ 2>&1 | grep -E "^(name|district|sentenced|offense)$" || echo "no garbage routes found"
+```
+
+Expected: `no garbage routes found`.
+
+- [ ] **Step 10: Run lint and existing tests**
+
+```bash
+pnpm lint
+pnpm test
+```
+
+Expected: both clean.
+
+- [ ] **Step 11: Commit the fresh DB-regeneration + close the issues**
+
+The DB file itself is gitignored per CLAUDE.md, so there's nothing to commit in this step. But if any incidental formatter changes were applied during verification, stage them.
+
+```bash
+but status
+# if any changes: but add <files>; but commit -m "chore: post-verification formatting"
+```
+
+Then open a PR with both issues closed in the body:
+
+```bash
+gh pr create --title "DB-backed pardon slugs (closes #12, #13)" --body "$(cat <<'EOF'
+## Summary
+- Move slug generation out of build-time `slugify()` calls into a post-scrape pass that writes a unique, first-wins, collision-resolved slug into a new `pardons.slug` column.
+- Fix a parser bug in `parseTableFour` and `parseTableFive` that was producing 20 garbage pardon rows on the Obama pages (literal "NAME"/"DISTRICT"/"SENTENCED"/"OFFENSE" header rows slipping through the `:has(th)` filter).
+- Pages now read `grant.data.slug` instead of recomputing, which closes the silent `getStaticPaths` dedup gap that had been dropping ~33 pardons from `dist/`.
+
+Closes #12. Closes #13.
+
+## Test plan
+- [x] `pnpm test` green (new: 3 table-four parser tests, 2 table-five parser tests, 10 slug-assigner tests)
+- [x] `pnpm lint` clean
+- [x] Fresh `pnpm scrape` completes, assigner logs "Assigned N slugs (M collision-resolved)"
+- [x] `sqlite3 data/pardonned.db "SELECT COUNT(*) FROM pardons WHERE slug IS NULL"` returns 0
+- [x] `sqlite3 data/pardonned.db "SELECT slug, COUNT(*) c FROM pardons GROUP BY slug HAVING c > 1"` returns no rows
+- [x] `pnpm build` produces one HTML page per DB row with no dedup gap
+- [x] `dist/pardon/details/alice-marie-johnson/index.html` and `dist/pardon/details/dwight-lincoln-hammond-2018-07-10-commutation/index.html` both exist and render correctly
+- [x] No `dist/pardon/details/name/`, `dist/pardon/details/district/`, etc.
+EOF
+)"
+```
+
+---
+
+## Verification checklist (summary)
+
+- Parser tests pass: `pnpm vitest run src/lib/parsers/__tests__/`
+- Slug-assigner tests pass: `pnpm vitest run src/lib/__tests__/slug-assigner.test.ts`
+- Existing slugify tests still pass (`slugify()` itself is unchanged): `pnpm vitest run src/lib/__tests__/slugify.test.ts`
+- DB has the column: `sqlite3 data/pardonned.db "PRAGMA table_info(pardons)"` lists `slug TEXT`
+- All rows have slugs: `SELECT COUNT(*) FROM pardons WHERE slug IS NULL` = 0
+- All slugs unique: `SELECT slug, COUNT(*) FROM pardons GROUP BY slug HAVING COUNT(*) > 1` = no rows
+- No garbage rows: `SELECT * FROM pardons WHERE recipient_name IN ('NAME','DISTRICT','SENTENCED','OFFENSE')` = no rows
+- Build page count matches row count: `pnpm build` log N equals the DB pardon count
+- Known-colliding names resolve to expected URLs (`alice-marie-johnson`, `dwight-lincoln-hammond-2018-07-10-commutation`, etc.)
+
+## Non-goals
+
+- The `brittany-krambeck` / `brittany-krambeck*` asterisk case is left as-is. That's a parser-level data-cleanup concern (strip trailing asterisks from names) that's adjacent but orthogonal to slug uniqueness. File a follow-up issue if needed.
+- Cross-administration name collisions (Joseph Schwartz, Connie Avalos, etc.) are resolved by the algorithm into date-suffixed slugs but NOT investigated for "are these actually the same person?". Domain call for the project owner.
+- No new "rules engine" DSL. The manual override map in `pardon-slug-overrides.ts` plus the collision escalation in `slug-assigner.ts` together satisfy issue #12's "rules engine" ask without adding a whole new abstraction.
+- No admin-scoped URLs (`/pardon/details/trump-2/jane-smith`). The first-wins + escalation chain covers every current collision class with flat URLs.
+- No changes to `slugify()` itself. The fallback hash-suffix logic remains for the very-long-name case, even though collision resolution now happens in a separate layer.

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -7,6 +7,7 @@ export interface NavItem {
 export const mainNavigation: NavItem[] = [
   { label: "Home", href: "/" },
   { label: "Search", href: "/search" },
+  { label: "About", href: "/about" },
 ];
 
 // Helper to check if a nav item is active

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,6 @@
 import { defineCollection } from "astro:content";
+import { glob } from "astro/loaders";
+import { z } from "astro/zod";
 import { pardonDetailsLoader, pardonDetailSchema } from "./loaders/pardon-details";
 
 const pardonDetails = defineCollection({
@@ -6,4 +8,12 @@ const pardonDetails = defineCollection({
   schema: pardonDetailSchema,
 });
 
-export const collections = { pardonDetails };
+const pages = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/pages" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+  }),
+});
+
+export const collections = { pardonDetails, pages };

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -1,0 +1,16 @@
+---
+title: About
+description: About Pardonned — an unofficial tracker of presidential pardons and commutations since 2000, inspired by Liz Oyer's work on pardon impropriety.
+---
+
+## What Is This Site?
+
+This is an unofficial tracker of pardons granted by US Presidents since 2000. The site is inspired by [Liz Oyer's](https://www.lawyeroyer.com/) videos and posts about the appearance of impropriety in presidential pardons, especially under President Donald Trump.
+
+## How Do We Get the Data?
+
+The data for the website is available through the [DOJ Website](https://www.justice.gov/pardon/clemency-recipients). We scrape the website once a day, and rebuild the database. The code for the parser and to see how this website is built is public and available at [github.com/vidluther/pardonned](https://github.com/vidluther/pardonned).
+
+## How Can You Help?
+
+I'd love your feedback and contributions! If you're a developer, send a PR or create an issue on GitHub. If you're not a developer but have ideas on how the site can be improved, reach out.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -24,6 +24,7 @@ export const pardons = sqliteTable(
       .notNull()
       .references(() => administrations.id),
     recipient_name: text("recipient_name").notNull(),
+    slug: text("slug").unique(),
     clemency_type: text("clemency_type", {
       enum: ["pardon", "commutation"],
     }).notNull(),

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly PARDONNED_DB: string;
+  readonly PUBLIC_POSTHOG_PROJECT_TOKEN: string;
+  readonly PUBLIC_POSTHOG_HOST: string;
 }
 
 interface ImportMeta {

--- a/src/lib/__tests__/slug-assigner.test.ts
+++ b/src/lib/__tests__/slug-assigner.test.ts
@@ -94,9 +94,9 @@ describe("assignSlugs", () => {
         row(2, "Alice", "2021-01-01", "pardon"),
         row(3, "Bob", "2020-01-01", "pardon"),
       ];
-      const a = assignSlugs(rows);
-      const b = assignSlugs(rows);
-      expect([...a.entries()].sort()).toEqual([...b.entries()].sort());
+      const byId = (m: Map<number, string>) =>
+        [...m.entries()].sort(([x], [y]) => x - y);
+      expect(byId(assignSlugs(rows))).toEqual(byId(assignSlugs(rows)));
     });
   });
 

--- a/src/lib/__tests__/slug-assigner.test.ts
+++ b/src/lib/__tests__/slug-assigner.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { assignSlugs, type AssignerRow } from "../slug-assigner";
+
+function row(
+  id: number,
+  name: string,
+  grant_date = "2020-01-01",
+  clemency_type: "pardon" | "commutation" = "pardon",
+): AssignerRow {
+  return { id, recipient_name: name, grant_date, clemency_type };
+}
+
+describe("assignSlugs", () => {
+  describe("no collisions", () => {
+    it("assigns the base slug to a single row", () => {
+      const result = assignSlugs([row(1, "Jane Smith")]);
+      expect(result.get(1)).toBe("jane-smith");
+    });
+
+    it("assigns distinct base slugs to rows with distinct names", () => {
+      const result = assignSlugs([row(1, "Jane Smith"), row(2, "John Doe")]);
+      expect(result.get(1)).toBe("jane-smith");
+      expect(result.get(2)).toBe("john-doe");
+    });
+  });
+
+  describe("first-wins collision: two rows, same name, different dates", () => {
+    it("first id keeps the base slug; second gets -date suffix", () => {
+      const rows = [
+        row(1, "Alice Marie Johnson", "2018-06-06", "commutation"),
+        row(2, "Alice Marie Johnson", "2020-08-28", "pardon"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("alice-marie-johnson");
+      expect(result.get(2)).toBe("alice-marie-johnson-2020-08-28");
+    });
+
+    it("first-wins is determined by id, not input order", () => {
+      // Deliberately reverse-order the input
+      const rows = [
+        row(2, "Alice Marie Johnson", "2020-08-28", "pardon"),
+        row(1, "Alice Marie Johnson", "2018-06-06", "commutation"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("alice-marie-johnson");
+      expect(result.get(2)).toBe("alice-marie-johnson-2020-08-28");
+    });
+  });
+
+  describe("escalation: same name AND same date", () => {
+    it("escalates to -date-type when -date collides (Hammonds case)", () => {
+      // Same person, same day, pardon + commutation
+      const rows = [
+        row(1, "Dwight Lincoln Hammond", "2018-07-10", "pardon"),
+        row(2, "Dwight Lincoln Hammond", "2018-07-10", "commutation"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("dwight-lincoln-hammond");
+      expect(result.get(2)).toBe("dwight-lincoln-hammond-2018-07-10-commutation");
+    });
+  });
+
+  describe("fallback: everything collides", () => {
+    it("uses -id suffix as the final fallback", () => {
+      // Three rows with identical name + date + type: unreachable IRL
+      // but the algorithm must still produce unique slugs.
+      const rows = [
+        row(1, "Jane Doe", "2020-01-01", "pardon"),
+        row(2, "Jane Doe", "2020-01-01", "pardon"),
+        row(3, "Jane Doe", "2020-01-01", "pardon"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.get(1)).toBe("jane-doe");
+      // Row 2's base collides, -date collides (2020-01-01), -date-type
+      // collides (jane-doe-2020-01-01-pardon), so it falls through to -id.
+      expect(result.get(2)).toBe("jane-doe-2");
+      expect(result.get(3)).toBe("jane-doe-3");
+    });
+  });
+
+  describe("respects slugify() overrides for the base slug", () => {
+    it("applies the Jan 6 Committee override as the base for a unique row", () => {
+      const jan6Name =
+        "The Members of Congress who served on the Select Committee to Investigate the January 6th Attack on the United States Capitol (\u201CSelect Committee\u201D); the staff of the Select Committee, as provided by House Resolution 503 (117th Congress); and the police officers from the D.C. Metropolitan Police Department or the U.S. Capitol Police who testified before the Select Committee";
+      const result = assignSlugs([row(1, jan6Name, "2025-01-19", "pardon")]);
+      expect(result.get(1)).toBe("january-6th-committee");
+    });
+  });
+
+  describe("determinism", () => {
+    it("produces identical output for identical input", () => {
+      const rows = [
+        row(1, "Alice", "2020-01-01", "pardon"),
+        row(2, "Alice", "2021-01-01", "pardon"),
+        row(3, "Bob", "2020-01-01", "pardon"),
+      ];
+      const a = assignSlugs(rows);
+      const b = assignSlugs(rows);
+      expect([...a.entries()].sort()).toEqual([...b.entries()].sort());
+    });
+  });
+
+  describe("every row gets a unique slug", () => {
+    it("post-condition: result size equals input size, all values distinct", () => {
+      const rows = [
+        row(1, "Alice", "2020-01-01", "pardon"),
+        row(2, "Alice", "2020-01-01", "commutation"),
+        row(3, "Alice", "2021-01-01", "pardon"),
+        row(4, "Bob"),
+        row(5, "Carol"),
+      ];
+      const result = assignSlugs(rows);
+      expect(result.size).toBe(rows.length);
+      const slugs = [...result.values()];
+      expect(new Set(slugs).size).toBe(slugs.length);
+    });
+  });
+});

--- a/src/lib/__tests__/slug-assigner.test.ts
+++ b/src/lib/__tests__/slug-assigner.test.ts
@@ -94,8 +94,7 @@ describe("assignSlugs", () => {
         row(2, "Alice", "2021-01-01", "pardon"),
         row(3, "Bob", "2020-01-01", "pardon"),
       ];
-      const byId = (m: Map<number, string>) =>
-        [...m.entries()].sort(([x], [y]) => x - y);
+      const byId = (m: Map<number, string>) => [...m.entries()].sort(([x], [y]) => x - y);
       expect(byId(assignSlugs(rows))).toEqual(byId(assignSlugs(rows)));
     });
   });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -336,16 +336,27 @@ await client.executeMultiple(DDL);
 // In-place migration: ALTER existing DBs that predate the slug column.
 // SQLite's CREATE TABLE IF NOT EXISTS won't add columns to an existing
 // table, so we check for the column via PRAGMA and ALTER if missing.
+// The pardons_slug_unique index is created unconditionally below, OUTSIDE
+// this block, because including it in the DDL string caused "no such
+// column: slug" errors on existing DBs (CREATE TABLE IF NOT EXISTS is a
+// no-op when the table exists, so the index ran before ALTER TABLE added
+// the column).
 {
   const cols = await client.execute("PRAGMA table_info(pardons)");
+  // PRAGMA table_info returns rows with columns: cid, name, type, notnull, dflt_value, pk.
+  // libsql exposes them as string-indexed properties, so r.name is the "name" column
+  // (the actual column name of the pardon row we're checking for).
   const hasSlug = cols.rows.some((r) => r.name === "slug");
   if (!hasSlug) {
     await client.execute("ALTER TABLE pardons ADD COLUMN slug TEXT");
     console.log("Migrated: added pardons.slug column");
   }
 }
-// Always ensure the unique index exists (idempotent; safe on both fresh
-// and migrated DBs because the slug column is guaranteed present above).
+// Always ensure the unique index exists (idempotent via IF NOT EXISTS).
+// Must stay OUTSIDE the DDL string and OUTSIDE the migration block:
+// on existing DBs the migration block adds the column first, and on
+// fresh DBs the DDL above creates the column. Either way, the index
+// creation here runs after the column is guaranteed to exist.
 await client.execute("CREATE UNIQUE INDEX IF NOT EXISTS pardons_slug_unique ON pardons(slug)");
 
 export const db = drizzle(client, { schema });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS pardons (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   administration INTEGER NOT NULL REFERENCES administrations(id),
   recipient_name TEXT NOT NULL,
+  slug TEXT,
   clemency_type TEXT NOT NULL CHECK(clemency_type IN ('pardon','commutation')),
   grant_date TEXT NOT NULL,
   warrant_url TEXT,
@@ -331,6 +332,21 @@ function getDbPath(): string {
 
 const client = createClient({ url: "file:" + getDbPath() });
 await client.executeMultiple(DDL);
+
+// In-place migration: ALTER existing DBs that predate the slug column.
+// SQLite's CREATE TABLE IF NOT EXISTS won't add columns to an existing
+// table, so we check for the column via PRAGMA and ALTER if missing.
+{
+  const cols = await client.execute("PRAGMA table_info(pardons)");
+  const hasSlug = cols.rows.some((r) => r.name === "slug");
+  if (!hasSlug) {
+    await client.execute("ALTER TABLE pardons ADD COLUMN slug TEXT");
+    console.log("Migrated: added pardons.slug column");
+  }
+}
+// Always ensure the unique index exists (idempotent; safe on both fresh
+// and migrated DBs because the slug column is guaranteed present above).
+await client.execute("CREATE UNIQUE INDEX IF NOT EXISTS pardons_slug_unique ON pardons(slug)");
 
 export const db = drizzle(client, { schema });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -506,6 +506,26 @@ export async function upsertGrants(
   return { inserted, skipped };
 }
 
+/**
+ * Load every pardon row, run them through the pure `assignSlugs` collision
+ * resolver, and write the results back to the `pardons.slug` column in a
+ * single transaction.
+ *
+ * Always operates on the full dataset, even when called from a single-
+ * president scrape (`pnpm scrape:trump2` etc.). This is deliberate:
+ * collision resolution needs to see every row, not just the subset that
+ * was freshly scraped, because a new trump-2 row can collide with an
+ * existing obama row by name.
+ *
+ * Returns `{ assigned, collisionsResolved }`:
+ * - `assigned` equals `slugMap.size`, which equals the total pardons row
+ *   count. The assigner algorithm is total (every row gets a slug), so
+ *   this is never a subset — treat it as a "rows the algorithm ran over"
+ *   counter, not "rows that changed."
+ * - `collisionsResolved` is a heuristic count of rows whose final slug
+ *   was escalated past the base form (see the comment on the counter
+ *   loop below for accuracy caveats).
+ */
 export async function assignAllPardonSlugs(): Promise<{
   assigned: number;
   collisionsResolved: number;
@@ -524,13 +544,14 @@ export async function assignAllPardonSlugs(): Promise<{
 
   // Count how many rows got anything other than a pure base slug — useful
   // as a scrape-log signal to notice regressions in the collision count.
+  // Rough signal, not a proof: matches any slug containing a YYYY-MM-DD
+  // pattern (covers base-date and base-date-type escalations) but MISSES
+  // rows that escalated all the way to `base-<id>` (which end in `-N`,
+  // not a date). The `-<id>` fallback is unreachable in current data but
+  // could happen in the future — don't trust this counter as exact.
   let collisionsResolved = 0;
   for (const row of rows) {
     const assigned = slugMap.get(row.id);
-    // A row's slug differs from its "clean" form iff collision escalation
-    // kicked in. We can't easily recompute the base here without duplicating
-    // slugify, so instead we count rows whose final slug contains a date
-    // or id suffix. This is a rough signal, not a proof.
     if (assigned && /-\d{4}-\d{2}-\d{2}/.test(assigned)) {
       collisionsResolved += 1;
     }
@@ -538,7 +559,10 @@ export async function assignAllPardonSlugs(): Promise<{
 
   // Write back in one transaction. Drizzle's libsql driver runs these as
   // individual UPDATE statements inside a transaction; for ~2,500 rows
-  // this is fast enough (sub-second on an M-series Mac).
+  // this is fast enough (sub-second on an M-series Mac). On any error
+  // (e.g., a UNIQUE constraint violation from a bug in assignSlugs),
+  // Drizzle rolls back the entire transaction — slugs are either all
+  // written or all left as NULL, never partially populated.
   await db.transaction(async (tx) => {
     for (const [id, slug] of slugMap) {
       await tx.update(pardons).set({ slug }).where(eq(pardons.id, id)).run();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -8,6 +8,7 @@ import type { ParsedGrant } from "./parsers/types.js";
 import { parseSentence } from "./parsers/sentences.js";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { assignSlugs } from "./slug-assigner.js";
 
 const DDL = `
 CREATE TABLE IF NOT EXISTS administrations (
@@ -503,4 +504,46 @@ export async function upsertGrants(
   }
 
   return { inserted, skipped };
+}
+
+export async function assignAllPardonSlugs(): Promise<{
+  assigned: number;
+  collisionsResolved: number;
+}> {
+  const rows = await db
+    .select({
+      id: pardons.id,
+      recipient_name: pardons.recipient_name,
+      grant_date: pardons.grant_date,
+      clemency_type: pardons.clemency_type,
+    })
+    .from(pardons)
+    .all();
+
+  const slugMap = assignSlugs(rows);
+
+  // Count how many rows got anything other than a pure base slug — useful
+  // as a scrape-log signal to notice regressions in the collision count.
+  let collisionsResolved = 0;
+  for (const row of rows) {
+    const assigned = slugMap.get(row.id);
+    // A row's slug differs from its "clean" form iff collision escalation
+    // kicked in. We can't easily recompute the base here without duplicating
+    // slugify, so instead we count rows whose final slug contains a date
+    // or id suffix. This is a rough signal, not a proof.
+    if (assigned && /-\d{4}-\d{2}-\d{2}/.test(assigned)) {
+      collisionsResolved += 1;
+    }
+  }
+
+  // Write back in one transaction. Drizzle's libsql driver runs these as
+  // individual UPDATE statements inside a transaction; for ~2,500 rows
+  // this is fast enough (sub-second on an M-series Mac).
+  await db.transaction(async (tx) => {
+    for (const [id, slug] of slugMap) {
+      await tx.update(pardons).set({ slug }).where(eq(pardons.id, id)).run();
+    }
+  });
+
+  return { assigned: slugMap.size, collisionsResolved };
 }

--- a/src/lib/pardon-slug-overrides.ts
+++ b/src/lib/pardon-slug-overrides.ts
@@ -6,6 +6,16 @@
  * The slug resolver in src/lib/slugify.ts checks this map first and falls
  * back to the computed slug path only if there's no override.
  *
+ * Role in the slug pipeline: this map is the EDITORIAL base-slug layer,
+ * consulted by slugify() at scrape time via src/lib/slug-assigner.ts when
+ * assigning the canonical slug for each row. Collision uniqueness is then
+ * enforced on top of the base slug by the assigner's escalation chain,
+ * and the final slug is stored in the pardons.slug column. The override
+ * map controls the *editorial* short form (e.g. "january-6th-committee")
+ * while the assigner controls *uniqueness* (e.g. "alice-marie-johnson"
+ * vs "alice-marie-johnson-2018-06-06"). These are intentionally separate
+ * concerns — don't move collision resolution into this map.
+ *
  * Rationale: about 21 pardon records have recipient_name values longer
  * than 50 characters — mostly because they include multiple "aka"/"fka"
  * aliases, or describe group clemency actions (e.g. the January 6 Select
@@ -27,7 +37,7 @@
  * fall through to the hash-suffixed fallback path. Do not add implicit
  * normalization inside slugify() — either update the caller to pass raw
  * values, or add the normalized form as an additional key alongside the
- * raw form. The longer-term fix is the planned DB-backed slug column.
+ * raw form.
  */
 export const PARDON_SLUG_OVERRIDES: Record<string, string> = {
   // Group clemency (biden-1): the 374-char full description of the Jan 6

--- a/src/lib/parsers/__tests__/key-value.test.ts
+++ b/src/lib/parsers/__tests__/key-value.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { parseKeyValue } from "../key-value";
+
+describe("parseKeyValue", () => {
+  it("skips column-header TH rows (NAME/DISTRICT/SENTENCED/OFFENSE)", () => {
+    // Regression test for the Obama DOJ pages where some sub-tables use
+    // <th> cells for column headers, not person names. Without the
+    // defensive skip, these produce garbage pardon records with
+    // recipient_name values of "NAME", "DISTRICT", "SENTENCED", "OFFENSE".
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th></tr>
+          <tr><th>Jane Doe</th></tr>
+          <tr><td></td><td>Jane Doe</td></tr>
+          <tr><td>Offense:</td><td>Mail fraud</td></tr>
+          <tr><td>Sentence:</td><td>24 months</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseKeyValue(html, "pardon", "https://example/");
+    const names = grants.map((g) => g.recipient_name);
+    expect(names).not.toContain("NAME");
+    expect(names).not.toContain("DISTRICT");
+    expect(names).not.toContain("SENTENCED");
+    expect(names).not.toContain("OFFENSE");
+  });
+
+  it("still treats a <th> cell with a real person name as a person row", () => {
+    // The Obama older format legitimately uses <th> for person names. The
+    // fix must not break this path — only the sentinel column-header names
+    // should be skipped.
+    const html = `
+      <html><body>
+        <h2>November 21, 2011</h2>
+        <table>
+          <tr><th>John Smith</th></tr>
+          <tr><td>Offense:</td><td>Drug possession</td></tr>
+          <tr><td>Sentence:</td><td>12 months</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseKeyValue(html, "pardon", "https://example/");
+    expect(grants.map((g) => g.recipient_name)).toContain("John Smith");
+  });
+});

--- a/src/lib/parsers/__tests__/table-five.test.ts
+++ b/src/lib/parsers/__tests__/table-five.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseTableFive } from "../table-five";
+
+describe("parseTableFive", () => {
+  it("parses a normal 5-column pardon row with warrant link", () => {
+    const html = `
+      <html><body>
+        <h2>December 22, 2020</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th><th>PUBLIC DISCLOSURE</th></tr>
+          <tr>
+            <td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td>
+            <td><a href="/pardon/file/123/dl">Download PDF Clemency Warrant</a></td>
+          </tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFive(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+    expect(grants[0].warrant_url).toContain("/pardon/file/123/dl");
+  });
+
+  it("skips header rows that use <td> instead of <th>", () => {
+    const html = `
+      <html><body>
+        <h2>December 22, 2020</h2>
+        <table>
+          <tr><td>NAME</td><td>DISTRICT</td><td>SENTENCED</td><td>OFFENSE</td><td>PUBLIC DISCLOSURE</td></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td><td></td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFive(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+  });
+});

--- a/src/lib/parsers/__tests__/table-four.test.ts
+++ b/src/lib/parsers/__tests__/table-four.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseTableFour } from "../table-four";
+
+describe("parseTableFour", () => {
+  it("parses a normal 4-column pardon row", () => {
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFour(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+  });
+
+  it("skips header rows that use <td> instead of <th>", () => {
+    // Obama-era DOJ HTML sometimes uses <td> for headers in later tables
+    // on the same page. The :has(th) filter misses these; a content-based
+    // check against the sentinel "NAME" value must catch them.
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><th>NAME</th><th>DISTRICT</th><th>SENTENCED</th><th>OFFENSE</th></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td></tr>
+        </table>
+        <h2>March 1, 2013</h2>
+        <table>
+          <tr><td>NAME</td><td>DISTRICT</td><td>SENTENCED</td><td>OFFENSE</td></tr>
+          <tr><td>John Smith</td><td>W.D. Tex.</td><td>12 months</td><td>Theft</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFour(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(2);
+    expect(grants.map((g) => g.recipient_name)).toEqual(["Jane Doe", "John Smith"]);
+    expect(grants.map((g) => g.recipient_name)).not.toContain("NAME");
+  });
+
+  it("skips header rows regardless of case", () => {
+    const html = `
+      <html><body>
+        <h2>January 16, 2016</h2>
+        <table>
+          <tr><td>name</td><td>district</td><td>sentenced</td><td>offense</td></tr>
+          <tr><td>Jane Doe</td><td>E.D. Cal.</td><td>24 months</td><td>Fraud</td></tr>
+        </table>
+      </body></html>
+    `;
+    const grants = parseTableFour(html, "pardon", "https://example/");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].recipient_name).toBe("Jane Doe");
+  });
+});

--- a/src/lib/parsers/key-value.ts
+++ b/src/lib/parsers/key-value.ts
@@ -96,9 +96,14 @@ function parseTable(
     if (cells.length === 0) {
       const thCells = $(row).find("th");
       if (thCells.length > 0) {
-        // TH rows contain person names — process each TH as a separate person
+        // TH rows contain person names — process each TH as a separate person.
+        // Defensive: some Obama sub-tables use <th> for COLUMN HEADERS, not
+        // person names (e.g. <th>NAME</th><th>DISTRICT</th>...). These slip
+        // past isNameValue() because the strings look name-ish. Skip any TH
+        // whose text matches a known column-header sentinel.
         thCells.each((_ti, th) => {
           const name = $(th).text().trim();
+          if (isHeaderSentinel(name)) return;
           if (name && isNameValue(name)) {
             // Flush previous person
             if (current?.name && currentDate) {
@@ -211,6 +216,17 @@ interface PersonRecord {
   district: string | null;
   sentence: string | null;
   terms: string | null;
+}
+
+/**
+ * Column-header strings that appear as <th> cells in some Obama sub-tables
+ * and would otherwise be parsed as "person" rows, producing garbage records
+ * with recipient_name values like "NAME"/"DISTRICT"/"SENTENCED"/"OFFENSE".
+ */
+const COLUMN_HEADER_SENTINELS = new Set(["NAME", "DISTRICT", "SENTENCED", "OFFENSE"]);
+
+function isHeaderSentinel(value: string): boolean {
+  return COLUMN_HEADER_SENTINELS.has(value.trim().toUpperCase());
 }
 
 /**

--- a/src/lib/parsers/table-five.ts
+++ b/src/lib/parsers/table-five.ts
@@ -39,6 +39,10 @@ export function parseTableFive(
 
       const name = cells.eq(0).text().trim();
       if (!name) return;
+      // Defensive: skip header rows that use <td> instead of <th>. The DOJ
+      // HTML is inconsistent across administrations — some sub-tables reuse
+      // <td> elements for their header rows and slip past the :has(th) filter
+      // above. Mirrors the same guard in table-four.ts (see Obama-era notes).
       if (name.toUpperCase() === "NAME") return;
 
       // District might be missing on some entries (e.g., Hunter Biden)

--- a/src/lib/parsers/table-five.ts
+++ b/src/lib/parsers/table-five.ts
@@ -39,6 +39,7 @@ export function parseTableFive(
 
       const name = cells.eq(0).text().trim();
       if (!name) return;
+      if (name.toUpperCase() === "NAME") return;
 
       // District might be missing on some entries (e.g., Hunter Biden)
       const district = cells.eq(1).text().trim() || null;

--- a/src/lib/parsers/table-four.ts
+++ b/src/lib/parsers/table-four.ts
@@ -37,6 +37,11 @@ export function parseTableFour(
 
       const name = cells.eq(0).text().trim();
       if (!name) return;
+      // Defensive: skip header rows that use <td> instead of <th>. Obama-era
+      // DOJ HTML is inconsistent — the first table on a page often has proper
+      // <th> headers (caught by the :has(th) filter above), but later tables
+      // on the same page reuse <td> for their header rows and slip through.
+      if (name.toUpperCase() === "NAME") return;
 
       const district = cells.eq(1).text().trim() || null;
       const sentence = cells.eq(2).text().trim() || null;

--- a/src/lib/slug-assigner.ts
+++ b/src/lib/slug-assigner.ts
@@ -1,0 +1,75 @@
+import { slugify } from "./slugify";
+
+export interface AssignerRow {
+  id: number;
+  recipient_name: string;
+  grant_date: string;
+  clemency_type: "pardon" | "commutation";
+}
+
+/**
+ * Assign a unique URL slug to every pardon row.
+ *
+ * Algorithm: deterministic pass in ascending `id` order. For each row,
+ * compute a base slug via `slugify(recipient_name)` (which consults the
+ * manual override map in `pardon-slug-overrides.ts` before falling back
+ * to the normalize-and-hash algorithm). Then walk a four-step escalation
+ * chain and claim the first candidate not already taken:
+ *
+ *   1. base
+ *   2. base-<grant_date>
+ *   3. base-<grant_date>-<clemency_type>
+ *   4. base-<id>   (guaranteed unique because ids are unique)
+ *
+ * The first-wins ordering is intentional: the row with the smallest id
+ * (typically the earliest-scraped one) keeps the clean base slug. Later
+ * colliding rows carry the disambiguation information in their URL.
+ *
+ * Every candidate in the winner row's chain is pre-claimed so that a
+ * subsequent row with the same base/date/type cannot "steal" a shorter
+ * form that belongs to this row's escalation chain. This forces proper
+ * escalation for rows sharing a base slug and a date.
+ *
+ * Returns a `Map<id, slug>`. The caller is responsible for writing the
+ * slugs back to the database; this function is pure so it can be tested
+ * without a DB.
+ */
+export function assignSlugs(rows: AssignerRow[]): Map<number, string> {
+  const sorted = [...rows].sort((a, b) => a.id - b.id);
+  const taken = new Set<string>();
+  const result = new Map<number, string>();
+
+  for (const row of sorted) {
+    const base = slugify(row.recipient_name);
+    const candidates = [
+      base,
+      `${base}-${row.grant_date}`,
+      `${base}-${row.grant_date}-${row.clemency_type}`,
+      `${base}-${row.id}`,
+    ];
+
+    // Find the first candidate not yet claimed by any earlier row.
+    let assigned: string | undefined;
+    for (const candidate of candidates) {
+      if (!taken.has(candidate)) {
+        assigned = candidate;
+        break;
+      }
+    }
+
+    // Pre-claim every candidate in this row's chain. Later rows sharing
+    // the same base/date/type will see these slots as taken and escalate
+    // past them.
+    for (const candidate of candidates) {
+      taken.add(candidate);
+    }
+
+    // assigned is always defined: `base-<id>` is unique because ids are unique
+    // and we pre-claim all candidates, so `base-<id>` for a prior row can
+    // only be in `taken` if a prior row's id happened to produce the same
+    // string — impossible since each id is distinct.
+    result.set(row.id, assigned!);
+  }
+
+  return result;
+}

--- a/src/lib/slug-assigner.ts
+++ b/src/lib/slug-assigner.ts
@@ -64,11 +64,17 @@ export function assignSlugs(rows: AssignerRow[]): Map<number, string> {
       taken.add(candidate);
     }
 
-    // assigned is always defined: `base-<id>` is unique because ids are unique
-    // and we pre-claim all candidates, so `base-<id>` for a prior row can
-    // only be in `taken` if a prior row's id happened to produce the same
-    // string — impossible since each id is distinct.
-    result.set(row.id, assigned!);
+    // The `base-${row.id}` fallback candidate (candidates[3]) is always
+    // available because row ids are unique per DB schema, so the first
+    // loop above is guaranteed to find at least one unclaimed candidate.
+    // If this throws, it means someone changed the candidate chain in a
+    // way that broke that guarantee — fix the chain, not this guard.
+    if (assigned === undefined) {
+      throw new Error(
+        `assignSlugs: no candidate found for id ${row.id} — this is a bug in the candidate chain`,
+      );
+    }
+    result.set(row.id, assigned);
   }
 
   return result;

--- a/src/loaders/pardon-details.ts
+++ b/src/loaders/pardon-details.ts
@@ -8,6 +8,7 @@ import { resolve } from "node:path";
 
 export const pardonDetailSchema = z.object({
   id: z.string(),
+  slug: z.string(),
   administration_slug: z.string(),
   grant_date: z.string(),
   clemency_type: z.enum(["pardon", "commutation"]),
@@ -71,6 +72,7 @@ export function pardonDetailsLoader(options: PardonDetailsLoaderOptions = {}): L
         const query = db
           .select({
             id: pardons.id,
+            slug: pardons.slug,
             administration_slug: administrations.slug,
             grant_date: pardons.grant_date,
             clemency_type: pardons.clemency_type,

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,10 @@
+---
+import Layout from "../layouts/Layout.astro";
+import "../styles/global.css";
+---
+
+<Layout
+    title="About"
+    description="About Pardonned - What this site is and how it came about"
+    ogImage="/og/search.png"
+/>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,10 +1,22 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import "../styles/global.css";
+import { getCollection, render } from "astro:content";
+
+const currentPath = Astro.url.pathname;
+const aboutEntries = await getCollection("pages", ({ id }) => id === "about");
+const about = aboutEntries[0];
+const { Content } = await render(about);
 ---
 
 <Layout
-    title="About"
-    description="About Pardonned - What this site is and how it came about"
-    ogImage="/og/search.png"
-/>
+    title={about.data.title}
+    description={about.data.description}
+    currentPath={currentPath}
+>
+    <section class="max-w-home mx-auto px-5 md:px-10 py-10 md:py-section">
+        <div class="max-w-source prose-content">
+            <Content />
+        </div>
+    </section>
+</Layout>

--- a/src/pages/og/[slug].png.ts
+++ b/src/pages/og/[slug].png.ts
@@ -1,6 +1,5 @@
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
-import { slugify } from "../../lib/slugify";
 import { renderOgImage, type OgImageData } from "../../lib/og-image";
 
 export const prerender = true;
@@ -29,7 +28,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
     const dateShort = formatDateShort(d.grant_date);
 
     return {
-      params: { slug: slugify(d.recipient_name) },
+      params: { slug: d.slug },
       props: {
         title: d.recipient_name,
         subtitle: `${clemencyLabel} · ${dateShort}`,

--- a/src/pages/pardon/details/[slug].astro
+++ b/src/pages/pardon/details/[slug].astro
@@ -193,7 +193,7 @@ const ogImagePath = `/og/${slugify(data.recipient_name)}.png`;
 ---
 
 <Layout title={data.recipient_name} description={ogDescription} ogImage={ogImagePath} currentPath={currentPath}>
-  <script type="application/ld+json" set:html={breadcrumbJsonLd} />
+  <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
     <div class="max-w-detail mx-auto px-5 md:px-10 py-6 md:py-10">
         <!-- Breadcrumb -->
         <div class="breadcrumb mb-6 md:mb-10">

--- a/src/pages/pardon/details/[slug].astro
+++ b/src/pages/pardon/details/[slug].astro
@@ -3,7 +3,6 @@ import Layout from "../../../layouts/Layout.astro";
 import StatCard from "../../../components/StatCard.astro";
 import "../../../styles/global.css";
 import { getCollection } from "astro:content";
-import { slugify } from "../../../lib/slugify";
 import { resolveUrl } from "../../../lib/parsers/types";
 import { generateBreadcrumbJsonLd } from "../../../lib/seo";
 
@@ -11,7 +10,7 @@ export async function getStaticPaths() {
     const allPardons = await getCollection("pardonDetails");
 
     return allPardons.map((grant) => ({
-        params: { slug: slugify(grant.data.recipient_name) },
+        params: { slug: grant.data.slug },
         props: { grant },
     }));
 }
@@ -179,7 +178,7 @@ const sources = [
 const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", url: "https://pardonned.com/" },
     { name: "Search", url: "https://pardonned.com/search" },
-    { name: data.recipient_name, url: `https://pardonned.com/pardon/details/${slugify(data.recipient_name)}` },
+    { name: data.recipient_name, url: `https://pardonned.com/pardon/details/${data.slug}` },
 ]);
 
 const ogDescriptionParts = [
@@ -189,7 +188,7 @@ if (hasRestitution) {
     ogDescriptionParts.push(`${formattedRestitution} in restitution abandoned.`);
 }
 const ogDescription = ogDescriptionParts.join(" ");
-const ogImagePath = `/og/${slugify(data.recipient_name)}.png`;
+const ogImagePath = `/og/${data.slug}.png`;
 ---
 
 <Layout title={data.recipient_name} description={ogDescription} ogImage={ogImagePath} currentPath={currentPath}>

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -10,7 +10,6 @@ import "../../styles/global.css";
 import { getCollection } from "astro:content";
 import { computeStats, filterByAdministration } from "../../lib/pardon-stats";
 import { getAdministrationIndex } from "../../lib/president-names";
-import { slugify } from "../../lib/slugify";
 
 const categoryColors: Record<string, string> = {
     fraud: "#8A6B1E",
@@ -76,7 +75,7 @@ const timelineEntries = sortedDates.map((date, i) => {
     const hrefs = grants.reduce(
         (acc, grant) => {
             acc[grant.recipient_name] =
-                `/pardon/details/${slugify(grant.recipient_name)}`;
+                `/pardon/details/${grant.slug}`;
             return acc;
         },
         {} as Record<string, string>,

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import FilterPill from '../components/FilterPill.astro';
 import '../styles/global.css';
 
 import { getCollection } from "astro:content";
@@ -49,7 +48,11 @@ function formatSentence(months: number | null, originalSentence: string | null):
     return "";
 }
 
-const searchResults = allGrants.map((entry) => {
+const sortedGrants = allGrants
+    .slice()
+    .sort((a, b) => b.data.grant_date.localeCompare(a.data.grant_date));
+
+const searchResults = sortedGrants.map((entry) => {
     const d = entry.data;
     return {
         slug: slugify(d.recipient_name),
@@ -59,6 +62,7 @@ const searchResults = allGrants.map((entry) => {
         offense: d.offense,
         district: d.district ?? "",
         sentence: formatSentence(d.sentence_in_months, d.original_sentence),
+        grantDate: d.grant_date,
         date: formatDate(d.grant_date),
         restitution: d.restitution ?? 0,
         fine: d.fine ?? 0,
@@ -70,6 +74,9 @@ const categoryCounts: Record<string, number> = {};
 for (const grant of searchResults) {
     categoryCounts[grant.category] = (categoryCounts[grant.category] ?? 0) + 1;
 }
+const sortedCategories = Object.entries(categoryCounts)
+    .sort(([, a], [, b]) => b - a)
+    .map(([key]) => key);
 ---
 
 <Layout
@@ -85,84 +92,158 @@ for (const grant of searchResults) {
       Filter and search through all clemency grants.
     </p>
 
-    <!-- Filter Bar -->
-    <div class="filter-bar mb-4">
-      <div class="flex flex-col sm:flex-row flex-wrap gap-3 items-stretch sm:items-center">
-        <div class="search-input-wrapper">
-          <svg aria-hidden="true" class="search-input-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-          <label for="search-input" class="sr-only">Search grants by name or offense</label>
-          <input
-            id="search-input"
-            type="text"
-            placeholder="Search by name or offense..."
-            class="filter-input w-full"
-          />
+    <div class="search-layout">
+      <aside class="search-sidebar">
+        <details class="search-sidebar-disclosure" id="sidebar-disclosure" open>
+          <summary class="search-sidebar-summary">
+            <span>Filters <span id="sidebar-active-count" class="text-text-faint"></span></span>
+            <span class="search-sidebar-summary-caret" aria-hidden="true"></span>
+          </summary>
+
+          <div class="search-sidebar-body">
+            <div class="search-sidebar-section">
+              <p class="overline">President</p>
+              <fieldset id="president-facets">
+                <legend class="sr-only">Filter by administration</legend>
+                <label class="facet-row" data-president="all">
+                  <span class="facet-row-label">
+                    <input type="radio" name="president" value="all" checked />
+                    <span>All</span>
+                  </span>
+                  <span class="facet-row-count" data-count-for="all">{searchResults.length.toLocaleString()}</span>
+                </label>
+                {sortedAdmins.map((admin) => (
+                  <label class="facet-row" data-president={admin.slug}>
+                    <span class="facet-row-label">
+                      <input type="radio" name="president" value={admin.slug} />
+                      <span>{admin.displayName}</span>
+                    </span>
+                    <span class="facet-row-count" data-count-for={admin.slug}>{admin.count.toLocaleString()}</span>
+                  </label>
+                ))}
+              </fieldset>
+            </div>
+
+            <div class="search-sidebar-section">
+              <p class="overline">Search</p>
+              <div class="search-input-wrapper">
+                <svg aria-hidden="true" class="search-input-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+                <label for="search-input" class="sr-only">Search grants by name or offense</label>
+                <input
+                  id="search-input"
+                  type="text"
+                  placeholder="Name or offense…"
+                  class="search-input-sidebar"
+                  autocomplete="off"
+                />
+              </div>
+            </div>
+
+            <div class="search-sidebar-section">
+              <p class="overline">Grant Type</p>
+              <fieldset id="type-segmented" class="type-segmented">
+                <legend class="sr-only">Filter by grant type</legend>
+                <label>
+                  <input type="radio" name="type" value="" class="sr-only" checked />
+                  <span class="type-segmented-option">All</span>
+                </label>
+                <label>
+                  <input type="radio" name="type" value="pardon" class="sr-only" />
+                  <span class="type-segmented-option">Pardon</span>
+                </label>
+                <label>
+                  <input type="radio" name="type" value="commutation" class="sr-only" />
+                  <span class="type-segmented-option">Commutation</span>
+                </label>
+              </fieldset>
+            </div>
+
+            <div class="search-sidebar-section">
+              <p class="overline">Category</p>
+              <fieldset id="category-facets">
+                <legend class="sr-only">Filter by offense category</legend>
+                {sortedCategories.map((key) => (
+                  <label class="facet-row" data-category={key}>
+                    <span class="facet-row-label">
+                      <input type="checkbox" name="category" value={key} />
+                      <span>{formatCategoryName(key)}</span>
+                    </span>
+                    <span class="facet-row-count" data-count-for-category={key}>{categoryCounts[key].toLocaleString()}</span>
+                  </label>
+                ))}
+              </fieldset>
+            </div>
+          </div>
+        </details>
+      </aside>
+
+      <section class="search-main min-w-0">
+        <div id="filter-summary" class="filter-summary">
+          <span>
+            <span id="filter-summary-count" class="filter-summary-count">{searchResults.length.toLocaleString()}</span>
+            <span class="filter-summary-total">of {searchResults.length.toLocaleString()} grants</span>
+          </span>
+          <span class="filter-summary-sep" aria-hidden="true"></span>
+          <div id="filter-summary-chips" class="flex flex-wrap items-center gap-2"></div>
+          <button type="button" id="filter-summary-clear" class="filter-summary-clear" hidden>Clear all</button>
         </div>
-        <label for="type-select" class="sr-only">Filter by clemency type</label>
-        <select id="type-select" class="filter-input !py-2 !px-3 !w-auto">
-          <option value="">All Types</option>
-          <option value="pardon">Pardon</option>
-          <option value="commutation">Commutation</option>
-        </select>
-      </div>
-    </div>
 
-    <!-- President Pills -->
-    <div id="president-pills" class="flex flex-wrap gap-2 mb-4">
-        <FilterPill label="All Presidents" active={true} count={searchResults.length} data-president="all" />
-        {sortedAdmins.map((admin) => (
-            <FilterPill
-                label={admin.displayName}
-                count={admin.count}
-                data-president={admin.slug}
-            />
-        ))}
-    </div>
+        <div id="a11y-results-announce" class="sr-only" aria-live="polite" role="status"></div>
 
-    <!-- Category Pills -->
-    <div id="category-pills" class="flex flex-wrap gap-2 mb-8">
-      <FilterPill label="All" active={true} count={searchResults.length} data-category="all" />
-      {Object.entries(categoryCounts)
-          .sort(([, a], [, b]) => b - a)
-          .map(([key, count]) => (
-          <FilterPill label={formatCategoryName(key)} count={count} data-category={key} />
-      ))}
-    </div>
+        <div id="results-list" class="results-swap"></div>
 
-    <!-- Results Count -->
-    <p id="results-count" class="text-meta text-text-faint mb-4" aria-live="polite" role="status">Showing {searchResults.length.toLocaleString()} results</p>
-
-    <!-- Results List (rendered client-side) -->
-    <div id="results-list"></div>
-
-    <!-- Empty State -->
-    <div id="empty-state" class="hidden text-center py-16">
-      <p class="text-faint text-lg mb-2">No results found</p>
-      <p class="text-faint">Try adjusting your filters or search terms.</p>
+        <div id="empty-state" class="hidden text-center py-16">
+          <p class="text-text-faint text-lg mb-2">No results found</p>
+          <p class="text-text-faint text-sm">Try adjusting your filters or search terms.</p>
+        </div>
+      </section>
     </div>
   </div>
 
   <script is:inline>
     document.addEventListener('DOMContentLoaded', () => {
-      const grantsData = document.getElementById('grants-data');
-      const colorsData = document.getElementById('category-colors');
-      if (!grantsData || !colorsData) return;
+      const grantsDataEl = document.getElementById('grants-data');
+      const colorsDataEl = document.getElementById('category-colors');
+      if (!grantsDataEl || !colorsDataEl) return;
 
-      const grants = JSON.parse(grantsData.textContent);
-      const categoryColors = JSON.parse(colorsData.textContent);
+      const grants = JSON.parse(grantsDataEl.textContent);
+      const categoryColors = JSON.parse(colorsDataEl.textContent);
+      const TOTAL = grants.length;
 
       const searchInput = document.getElementById('search-input');
-      const typeSelect = document.getElementById('type-select');
+      const typeSegmented = document.getElementById('type-segmented');
+      const presidentFacets = document.getElementById('president-facets');
+      const categoryFacets = document.getElementById('category-facets');
       const resultsList = document.getElementById('results-list');
       const emptyState = document.getElementById('empty-state');
-      const resultsCount = document.getElementById('results-count');
-      const categoryPills = document.getElementById('category-pills');
+      const filterSummary = document.getElementById('filter-summary');
+      const filterSummaryCount = document.getElementById('filter-summary-count');
+      const filterSummaryChips = document.getElementById('filter-summary-chips');
+      const filterSummaryClear = document.getElementById('filter-summary-clear');
+      const sidebarActiveCount = document.getElementById('sidebar-active-count');
+      const a11yAnnounce = document.getElementById('a11y-results-announce');
+      const sidebarDisclosure = document.getElementById('sidebar-disclosure');
 
-      let activeCategory = 'all';
-      let activePresident = 'all';
+      const presidentLabels = { all: 'All' };
+      presidentFacets.querySelectorAll('label[data-president]').forEach((label) => {
+        const slug = label.dataset.president;
+        const textSpan = label.querySelector('.facet-row-label > span:last-child');
+        if (textSpan) presidentLabels[slug] = textSpan.textContent;
+      });
+
+      const state = {
+        search: '',
+        type: '',
+        president: 'all',
+        categories: new Set(),
+      };
+
+      function formatCategoryName(key) {
+        return key.replace(/\b\w/g, (c) => c.toUpperCase());
+      }
 
       function formatRestitution(value) {
         if (value >= 1000000) return `$${(value / 1000000).toFixed(1)}M`;
@@ -170,227 +251,469 @@ for (const grant of searchResults) {
         return `$${value.toLocaleString()}`;
       }
 
-      function formatCategoryName(key) {
-        return key.replace(/\b\w/g, (c) => c.toUpperCase());
+      function findInputByValue(root, name, value) {
+        const inputs = root.querySelectorAll(`input[name="${name}"]`);
+        for (const el of inputs) {
+          if (el.value === value) return el;
+        }
+        return null;
+      }
+
+      function grantMatches(grant, skip) {
+        if (!skip?.search && state.search) {
+          const s = state.search.toLowerCase();
+          if (!grant.name.toLowerCase().includes(s) && !grant.offense.toLowerCase().includes(s)) {
+            return false;
+          }
+        }
+        if (!skip?.type && state.type && grant.clemencyType !== state.type) {
+          return false;
+        }
+        if (!skip?.president && state.president !== 'all' && grant.administrationSlug !== state.president) {
+          return false;
+        }
+        if (!skip?.categories && state.categories.size > 0 && !state.categories.has(grant.category)) {
+          return false;
+        }
+        return true;
+      }
+
+      function getFilteredGrants() {
+        return grants.filter((g) => grantMatches(g));
+      }
+
+      function computeFilteredCounts() {
+        const byPresident = { all: 0 };
+        const byCategory = {};
+
+        for (const g of grants) {
+          if (grantMatches(g, { president: true })) {
+            byPresident.all += 1;
+            byPresident[g.administrationSlug] = (byPresident[g.administrationSlug] ?? 0) + 1;
+          }
+          if (grantMatches(g, { categories: true })) {
+            byCategory[g.category] = (byCategory[g.category] ?? 0) + 1;
+          }
+        }
+        return { byPresident, byCategory };
+      }
+
+      function renderSidebarCounts(counts) {
+        presidentFacets.querySelectorAll('label[data-president]').forEach((label) => {
+          const slug = label.dataset.president;
+          const count = counts.byPresident[slug] ?? 0;
+          const countEl = label.querySelector('.facet-row-count');
+          if (countEl) countEl.textContent = count.toLocaleString();
+          const isCurrent = state.president === slug;
+          if (count === 0 && !isCurrent) {
+            label.classList.add('facet-row-disabled');
+          } else {
+            label.classList.remove('facet-row-disabled');
+          }
+        });
+
+        categoryFacets.querySelectorAll('label[data-category]').forEach((label) => {
+          const key = label.dataset.category;
+          const count = counts.byCategory[key] ?? 0;
+          const countEl = label.querySelector('.facet-row-count');
+          if (countEl) countEl.textContent = count.toLocaleString();
+          const isChecked = state.categories.has(key);
+          if (count === 0 && !isChecked) {
+            label.classList.add('facet-row-disabled');
+          } else {
+            label.classList.remove('facet-row-disabled');
+          }
+        });
+      }
+
+      function makeChip(label, action) {
+        const el = document.createElement('span');
+        el.className = 'filter-chip';
+        el.textContent = label + ' ';
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'filter-chip-remove';
+        btn.setAttribute('aria-label', `Remove ${label} filter`);
+        btn.dataset.action = action;
+        btn.textContent = '\u00D7';
+        el.appendChild(btn);
+        return el;
+      }
+
+      function renderFilterSummary(filtered) {
+        filterSummaryCount.textContent = filtered.length.toLocaleString();
+
+        const chips = [];
+        if (state.search) {
+          chips.push({ label: `"${state.search}"`, action: 'clear-search' });
+        }
+        if (state.type) {
+          chips.push({
+            label: state.type === 'pardon' ? 'Pardon' : 'Commutation',
+            action: 'clear-type',
+          });
+        }
+        if (state.president !== 'all') {
+          chips.push({
+            label: presidentLabels[state.president] ?? state.president,
+            action: 'clear-president',
+          });
+        }
+        for (const cat of state.categories) {
+          chips.push({
+            label: formatCategoryName(cat),
+            action: 'clear-category:' + cat,
+          });
+        }
+
+        filterSummaryChips.textContent = '';
+        for (const chip of chips) {
+          filterSummaryChips.appendChild(makeChip(chip.label, chip.action));
+        }
+
+        filterSummaryClear.hidden = chips.length === 0;
+        const sep = filterSummary.querySelector('.filter-summary-sep');
+        if (sep) sep.hidden = chips.length === 0;
+        sidebarActiveCount.textContent = chips.length > 0 ? `(${chips.length} active)` : '';
+
+        const chipText = chips.map((c) => c.label).join(', ');
+        a11yAnnounce.textContent =
+          `${filtered.length.toLocaleString()} of ${TOTAL.toLocaleString()} results` +
+          (chipText ? `, filtered by ${chipText}` : '');
       }
 
       function renderResults(filtered) {
-        if (filtered.length === 0) {
+        resultsList.classList.add('is-swapping');
+
+        requestAnimationFrame(() => {
+          if (filtered.length === 0) {
+            resultsList.textContent = '';
+            emptyState.classList.remove('hidden');
+            resultsList.classList.remove('is-swapping');
+            return;
+          }
+
+          emptyState.classList.add('hidden');
           resultsList.textContent = '';
-          emptyState.classList.remove('hidden');
-          resultsCount.textContent = 'No results';
-          return;
+
+          filtered.forEach((grant, i) => {
+            const catLabel = formatCategoryName(grant.category);
+            const catColor = categoryColors[grant.category] || '#7A7870';
+            const typeLabel = grant.clemencyType === 'pardon' ? 'Pardon' : 'Commutation';
+
+            const card = document.createElement('a');
+            card.href = '/pardon/details/' + grant.slug;
+            card.className = 'search-card block no-underline mb-3' + (i < 10 ? ' animate-fade-in' : '');
+            card.style.borderLeftColor = catColor;
+            if (i < 10) card.style.animationDelay = (i * 35) + 'ms';
+
+            const outer = document.createElement('div');
+            outer.className = 'flex items-start gap-3';
+
+            const content = document.createElement('div');
+            content.className = 'flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 flex-1 min-w-0';
+
+            const left = document.createElement('div');
+            left.className = 'flex-1 min-w-0';
+
+            const nameEl = document.createElement('div');
+            nameEl.className = 'font-serif text-text-primary mb-1';
+            nameEl.style.fontSize = '17px';
+            nameEl.style.lineHeight = '1.25';
+            nameEl.textContent = grant.name;
+            left.appendChild(nameEl);
+
+            const metaLine = document.createElement('div');
+            metaLine.className = 'flex items-center gap-2 mb-2';
+            metaLine.style.fontSize = '11px';
+            metaLine.style.textTransform = 'uppercase';
+            metaLine.style.letterSpacing = '0.06em';
+
+            const typeEl = document.createElement('span');
+            typeEl.textContent = typeLabel;
+            typeEl.style.color = grant.clemencyType === 'pardon' ? '#c23b22' : '#2a6a7a';
+            typeEl.style.fontWeight = '500';
+            metaLine.appendChild(typeEl);
+
+            const sepEl = document.createElement('span');
+            sepEl.textContent = '\u00B7';
+            sepEl.style.color = '#b8b6ae';
+            metaLine.appendChild(sepEl);
+
+            const catEl = document.createElement('span');
+            catEl.textContent = catLabel;
+            catEl.style.color = catColor;
+            metaLine.appendChild(catEl);
+
+            left.appendChild(metaLine);
+
+            const offense = document.createElement('p');
+            offense.className = 'text-card-offense text-text-secondary line-clamp-2';
+            offense.textContent = grant.offense;
+            left.appendChild(offense);
+
+            if (grant.district || grant.sentence) {
+              const meta = document.createElement('div');
+              meta.className = 'flex flex-wrap gap-3 text-meta text-text-faint mt-1';
+              if (grant.district) {
+                const d = document.createElement('span');
+                d.textContent = grant.district;
+                meta.appendChild(d);
+              }
+              if (grant.sentence) {
+                const s = document.createElement('span');
+                s.textContent = grant.sentence;
+                meta.appendChild(s);
+              }
+              left.appendChild(meta);
+            }
+
+            content.appendChild(left);
+
+            const right = document.createElement('div');
+            right.className = 'flex sm:flex-col sm:text-right gap-3 sm:gap-0 sm:ml-4 flex-shrink-0 items-center sm:items-end';
+
+            const dateDiv = document.createElement('div');
+            dateDiv.className = 'text-meta text-text-faint sm:mb-1';
+            dateDiv.style.fontVariantNumeric = 'tabular-nums';
+            dateDiv.textContent = grant.date;
+            right.appendChild(dateDiv);
+
+            if (grant.restitution) {
+              const restVal = document.createElement('div');
+              restVal.className = 'text-body font-medium text-accent';
+              restVal.textContent = formatRestitution(grant.restitution);
+              right.appendChild(restVal);
+
+              const restLabel = document.createElement('div');
+              restLabel.className = 'text-badge text-text-faint';
+              restLabel.textContent = 'restitution';
+              right.appendChild(restLabel);
+            }
+
+            content.appendChild(right);
+            outer.appendChild(content);
+
+            const chevron = document.createElement('span');
+            chevron.className = 'search-card-chevron hidden sm:block';
+            chevron.textContent = '\u203A';
+            outer.appendChild(chevron);
+
+            card.appendChild(outer);
+            resultsList.appendChild(card);
+          });
+
+          resultsList.classList.remove('is-swapping');
+        });
+      }
+
+      function syncUrl() {
+        const params = new URLSearchParams();
+        if (state.search) params.set('q', state.search);
+        if (state.type) params.set('type', state.type);
+        if (state.president !== 'all') params.set('president', state.president);
+        if (state.categories.size > 0) params.set('categories', Array.from(state.categories).join(','));
+
+        const qs = params.toString();
+        const next = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+        const current = window.location.pathname + window.location.search;
+        if (next !== current) {
+          history.replaceState(null, '', next);
         }
-
-        emptyState.classList.add('hidden');
-        resultsCount.textContent = `Showing ${filtered.length.toLocaleString()} results`;
-
-        // Clear previous results
-        resultsList.textContent = '';
-
-        filtered.forEach((grant, i) => {
-          const catLabel = formatCategoryName(grant.category);
-          const catColor = categoryColors[grant.category] || '#7A7870';
-          const typeLabel = grant.clemencyType === 'pardon' ? 'Pardon' : 'Commutation';
-          const typeBadgeClass = grant.clemencyType === 'pardon' ? 'badge-pardon' : 'badge-commutation';
-
-          const card = document.createElement('a');
-          card.href = '/pardon/details/' + grant.slug;
-          card.className = 'search-card block no-underline mb-3' + (i < 10 ? ' animate-fade-in' : '');
-          card.style.borderLeftColor = catColor;
-          if (i < 10) card.style.animationDelay = (i * 40) + 'ms';
-
-          // Outer flex container
-          const outer = document.createElement('div');
-          outer.className = 'flex items-center gap-3';
-
-          // Content area
-          const content = document.createElement('div');
-          content.className = 'flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 flex-1 min-w-0';
-
-          // Left side
-          const left = document.createElement('div');
-          left.className = 'flex-1 min-w-0';
-
-          // Name row
-          const nameRow = document.createElement('div');
-          nameRow.className = 'flex items-center gap-2 sm:gap-3 mb-2 flex-wrap';
-
-          const nameSpan = document.createElement('span');
-          nameSpan.className = 'font-serif text-text-primary';
-          nameSpan.style.fontSize = '17px';
-          nameSpan.textContent = grant.name;
-
-          const typeBadge = document.createElement('span');
-          typeBadge.className = 'badge ' + typeBadgeClass;
-          typeBadge.textContent = typeLabel;
-
-          const catBadge = document.createElement('span');
-          catBadge.className = 'badge badge-category';
-          catBadge.style.color = catColor;
-          catBadge.textContent = catLabel;
-
-          nameRow.appendChild(nameSpan);
-          nameRow.appendChild(typeBadge);
-          nameRow.appendChild(catBadge);
-          left.appendChild(nameRow);
-
-          // Offense
-          const offense = document.createElement('p');
-          offense.className = 'text-card-offense text-text-secondary mb-1 line-clamp-2';
-          offense.textContent = grant.offense;
-          left.appendChild(offense);
-
-          // Meta row
-          if (grant.district || grant.sentence) {
-            const meta = document.createElement('div');
-            meta.className = 'flex gap-4 text-meta text-text-faint mt-1';
-            if (grant.district) {
-              const d = document.createElement('span');
-              d.textContent = grant.district;
-              meta.appendChild(d);
-            }
-            if (grant.sentence) {
-              const s = document.createElement('span');
-              s.textContent = grant.sentence;
-              meta.appendChild(s);
-            }
-            left.appendChild(meta);
-          }
-
-          content.appendChild(left);
-
-          // Right side
-          const right = document.createElement('div');
-          right.className = 'flex sm:flex-col sm:text-right gap-3 sm:gap-0 sm:ml-4 flex-shrink-0 items-center sm:items-end';
-
-          const dateDiv = document.createElement('div');
-          dateDiv.className = 'text-meta text-text-faint sm:mb-1';
-          dateDiv.textContent = grant.date;
-          right.appendChild(dateDiv);
-
-          if (grant.restitution) {
-            const restVal = document.createElement('div');
-            restVal.className = 'text-body font-medium text-accent';
-            restVal.textContent = formatRestitution(grant.restitution);
-            right.appendChild(restVal);
-
-            const restLabel = document.createElement('div');
-            restLabel.className = 'text-badge text-text-faint';
-            restLabel.textContent = 'restitution';
-            right.appendChild(restLabel);
-          }
-
-          content.appendChild(right);
-          outer.appendChild(content);
-
-          // Chevron
-          const chevron = document.createElement('span');
-          chevron.className = 'search-card-chevron hidden sm:block';
-          chevron.innerHTML = '&#8250;';
-          outer.appendChild(chevron);
-
-          card.appendChild(outer);
-          resultsList.appendChild(card);
-        });
       }
 
-      function filterGrants() {
-        const searchTerm = searchInput.value.toLowerCase();
-        const typeFilter = typeSelect.value;
-
-        let filtered = grants.filter((grant) => {
-          const matchesSearch = !searchTerm || grant.name.toLowerCase().includes(searchTerm) || grant.offense.toLowerCase().includes(searchTerm);
-          const matchesType = !typeFilter || grant.clemencyType === typeFilter;
-          const matchesCategory = activeCategory === 'all' || grant.category === activeCategory;
-          const matchesPresident = activePresident === 'all' || grant.administrationSlug === activePresident;
-          return matchesSearch && matchesType && matchesCategory && matchesPresident;
-        });
-
+      function applyState() {
+        const filtered = getFilteredGrants();
         renderResults(filtered);
+        const counts = computeFilteredCounts();
+        renderSidebarCounts(counts);
+        renderFilterSummary(filtered);
+        syncUrl();
       }
 
-      function setActivePill(pill, containerId) {
-        const container = document.getElementById(containerId);
-        container.querySelectorAll('button, a').forEach((p) => {
-          p.classList.remove('filter-pill-active');
-          p.classList.add('filter-pill-inactive');
-        });
-        pill.classList.remove('filter-pill-inactive');
-        pill.classList.add('filter-pill-active');
-      }
-
-      // Debounced search tracking
       let searchDebounce;
       searchInput.addEventListener('input', () => {
-        filterGrants();
+        state.search = searchInput.value.trim();
+        applyState();
         clearTimeout(searchDebounce);
         searchDebounce = setTimeout(() => {
-          const term = searchInput.value.trim();
-          if (term) {
-            window.posthog?.capture('search_performed', { query: term });
+          if (state.search) {
+            const resultsCount = getFilteredGrants().length;
+            window.posthog?.capture('search_performed', {
+              query: state.search,
+              results_count: resultsCount,
+              has_results: resultsCount > 0,
+              active_filters: {
+                type: state.type || null,
+                president: state.president !== 'all' ? state.president : null,
+                categories_count: state.categories.size,
+              },
+            });
           }
         }, 600);
       });
 
-      typeSelect.addEventListener('change', () => {
-        filterGrants();
-        if (typeSelect.value) {
-          window.posthog?.capture('type_filter_applied', { type: typeSelect.value });
+      typeSegmented.addEventListener('change', (e) => {
+        const t = e.target;
+        if (t && t.name === 'type') {
+          state.type = t.value;
+          applyState();
+          if (state.type) {
+            window.posthog?.capture('type_filter_applied', { type: state.type });
+          }
         }
       });
 
-      categoryPills.addEventListener('click', (e) => {
-        const pill = e.target.closest('button, a');
-        if (!pill) return;
-
-        activeCategory = pill.dataset.category || 'all';
-        setActivePill(pill, 'category-pills');
-        filterGrants();
-        window.posthog?.capture('category_filter_applied', { category: activeCategory });
+      presidentFacets.addEventListener('change', (e) => {
+        const t = e.target;
+        if (t && t.name === 'president') {
+          state.president = t.value;
+          applyState();
+          if (state.president !== 'all') {
+            window.posthog?.capture('president_filter_applied', { president: state.president });
+          }
+        }
       });
 
-      const presidentPills = document.getElementById('president-pills');
-      presidentPills.addEventListener('click', (e) => {
-        const pill = e.target.closest('button, a');
-        if (!pill) return;
-
-        activePresident = pill.dataset.president || 'all';
-        setActivePill(pill, 'president-pills');
-        filterGrants();
-        window.posthog?.capture('president_filter_applied', { president: activePresident });
+      categoryFacets.addEventListener('change', (e) => {
+        const t = e.target;
+        if (t && t.name === 'category') {
+          if (t.checked) {
+            state.categories.add(t.value);
+          } else {
+            state.categories.delete(t.value);
+          }
+          applyState();
+          window.posthog?.capture('category_filter_applied', { category: t.value, checked: t.checked });
+        }
       });
 
-      // Track search result clicks
+      filterSummary.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-action]');
+        if (!btn) return;
+        const action = btn.dataset.action;
+        if (action === 'clear-search') {
+          state.search = '';
+          searchInput.value = '';
+        } else if (action === 'clear-type') {
+          state.type = '';
+          const allTypeRadio = findInputByValue(typeSegmented, 'type', '');
+          if (allTypeRadio) allTypeRadio.checked = true;
+        } else if (action === 'clear-president') {
+          state.president = 'all';
+          const allPresRadio = findInputByValue(presidentFacets, 'president', 'all');
+          if (allPresRadio) allPresRadio.checked = true;
+        } else if (action && action.startsWith('clear-category:')) {
+          const key = action.slice('clear-category:'.length);
+          state.categories.delete(key);
+          const cb = findInputByValue(categoryFacets, 'category', key);
+          if (cb) cb.checked = false;
+        }
+        applyState();
+        window.posthog?.capture('search_filters_cleared', {
+          source: 'chip_remove',
+          filter_type: action,
+        });
+      });
+
+      filterSummaryClear.addEventListener('click', () => {
+        const priorFilterCount =
+          (state.search ? 1 : 0) +
+          (state.type ? 1 : 0) +
+          (state.president !== 'all' ? 1 : 0) +
+          state.categories.size;
+
+        state.search = '';
+        state.type = '';
+        state.president = 'all';
+        state.categories.clear();
+
+        searchInput.value = '';
+        const allType = findInputByValue(typeSegmented, 'type', '');
+        if (allType) allType.checked = true;
+        const allPres = findInputByValue(presidentFacets, 'president', 'all');
+        if (allPres) allPres.checked = true;
+        categoryFacets.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+          cb.checked = false;
+        });
+
+        applyState();
+        window.posthog?.capture('search_filters_cleared', {
+          source: 'clear_all_button',
+          filter_count: priorFilterCount,
+        });
+      });
+
       resultsList.addEventListener('click', (e) => {
         const card = e.target.closest('a.search-card');
         if (!card) return;
         const slug = card.href.split('/pardon/details/')[1];
-        window.posthog?.capture('search_result_clicked', { slug });
+        const cards = Array.from(resultsList.children);
+        window.posthog?.capture('search_result_clicked', {
+          slug,
+          query: state.search || null,
+          position: cards.indexOf(card),
+          total_results: cards.length,
+          has_active_filters:
+            Boolean(state.search) ||
+            Boolean(state.type) ||
+            state.president !== 'all' ||
+            state.categories.size > 0,
+        });
       });
 
-      // Apply URL params as initial filters
+      const desktopMq = window.matchMedia('(min-width: 1024px)');
+      const enforceDesktopOpen = () => {
+        if (desktopMq.matches && sidebarDisclosure && !sidebarDisclosure.open) {
+          sidebarDisclosure.open = true;
+        }
+      };
+      enforceDesktopOpen();
+      desktopMq.addEventListener('change', enforceDesktopOpen);
+
       const urlParams = new URLSearchParams(window.location.search);
 
-      const initialPresident = urlParams.get('president');
-      if (initialPresident) {
-        const matchingPill = presidentPills.querySelector(`[data-president="${initialPresident}"]`);
-        if (matchingPill) {
-          activePresident = initialPresident;
-          setActivePill(matchingPill, 'president-pills');
+      const qParam = urlParams.get('q');
+      if (qParam) {
+        state.search = qParam.trim();
+        searchInput.value = state.search;
+      }
+
+      const typeParam = urlParams.get('type');
+      if (typeParam === 'pardon' || typeParam === 'commutation') {
+        state.type = typeParam;
+        const radio = findInputByValue(typeSegmented, 'type', typeParam);
+        if (radio) radio.checked = true;
+      }
+
+      const presParam = urlParams.get('president');
+      if (presParam) {
+        const pradio = findInputByValue(presidentFacets, 'president', presParam);
+        if (pradio) {
+          state.president = presParam;
+          pradio.checked = true;
         }
       }
 
-      const initialCategory = urlParams.get('category');
-      if (initialCategory) {
-        const matchingPill = categoryPills.querySelector(`[data-category="${initialCategory}"]`);
-        if (matchingPill) {
-          activeCategory = initialCategory;
-          setActivePill(matchingPill, 'category-pills');
+      const catsParam = urlParams.get('categories');
+      const legacyCatParam = urlParams.get('category');
+      const catsToApply = catsParam
+        ? catsParam.split(',')
+        : legacyCatParam
+          ? [legacyCatParam]
+          : [];
+      catsToApply.forEach((c) => {
+        const key = c.trim();
+        if (!key) return;
+        const cb = findInputByValue(categoryFacets, 'category', key);
+        if (cb) {
+          state.categories.add(key);
+          cb.checked = true;
         }
-      }
+      });
 
-      filterGrants();
+      applyState();
     });
   </script>
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -3,7 +3,6 @@ import Layout from '../layouts/Layout.astro';
 import '../styles/global.css';
 
 import { getCollection } from "astro:content";
-import { slugify } from "../lib/slugify";
 import { getAdministrationIndex } from "../lib/president-names";
 
 const currentPath = Astro.url.pathname;
@@ -55,7 +54,7 @@ const sortedGrants = allGrants
 const searchResults = sortedGrants.map((entry) => {
     const d = entry.data;
     return {
-        slug: slugify(d.recipient_name),
+        slug: d.slug,
         name: d.recipient_name,
         clemencyType: d.clemency_type,
         category: d.offense_category,

--- a/src/scraper/scrape.ts
+++ b/src/scraper/scrape.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { fetchPageHtml, closeBrowser } from "./browser.js";
-import { upsertGrants } from "../lib/db.js";
+import { upsertGrants, assignAllPardonSlugs } from "../lib/db.js";
 import { PRESIDENT_SOURCES } from "./presidents.js";
 import { detectFormat } from "../lib/parsers/detect.js";
 import { parseTrump2025 } from "../lib/parsers/trump2025.js";
@@ -97,6 +97,10 @@ async function main(): Promise<void> {
     } else {
       await scrapePresident(presidentFilter);
     }
+
+    console.log("\nAssigning slugs...");
+    const { assigned, collisionsResolved } = await assignAllPardonSlugs();
+    console.log(`  Assigned ${assigned} slugs (${collisionsResolved} collision-resolved)`);
   } finally {
     await closeBrowser();
   }

--- a/src/scraper/scrape.ts
+++ b/src/scraper/scrape.ts
@@ -98,6 +98,9 @@ async function main(): Promise<void> {
       await scrapePresident(presidentFilter);
     }
 
+    // Always runs across ALL pardon rows, not just the president that
+    // was scraped — collision resolution needs the full dataset to be
+    // correct. So `pnpm scrape:trump2` will still log ~2,500 assigned.
     console.log("\nAssigning slugs...");
     const { assigned, collisionsResolved } = await assignAllPardonSlugs();
     console.log(`  Assigned ${assigned} slugs (${collisionsResolved} collision-resolved)`);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -997,4 +997,30 @@
   .leading-relaxed {
     line-height: 1.8;
   }
+
+  .prose-content {
+    & h2 {
+      margin-top: 2.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    & h2:first-child {
+      margin-top: 0;
+    }
+
+    & p {
+      margin-bottom: 1rem;
+      line-height: 1.8;
+    }
+
+    & a {
+      color: var(--color-accent, #c23b22);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    & a:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -556,6 +556,374 @@
       display: none !important;
     }
   }
+
+  /* Search page — editorial sidebar layout */
+  .search-layout {
+    display: block;
+  }
+
+  @media (min-width: 1024px) {
+    .search-layout {
+      display: grid;
+      grid-template-columns: 240px 1fr;
+      gap: 40px;
+      align-items: start;
+    }
+  }
+
+  .search-sidebar {
+    margin-bottom: 24px;
+  }
+
+  @media (min-width: 1024px) {
+    .search-sidebar {
+      position: sticky;
+      top: 24px;
+      max-height: calc(100vh - 48px);
+      overflow-y: auto;
+      margin-bottom: 0;
+      padding-right: 8px;
+    }
+  }
+
+  .search-sidebar-disclosure {
+    border: 1px solid #e8e6e0;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  @media (min-width: 1024px) {
+    .search-sidebar-disclosure {
+      border: none;
+      background: transparent;
+      border-radius: 0;
+    }
+  }
+
+  .search-sidebar-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #1a1918;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+  }
+
+  .search-sidebar-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .search-sidebar-summary-caret {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-right: 1.5px solid #7a7870;
+    border-bottom: 1.5px solid #7a7870;
+    transform: rotate(45deg);
+    transition: transform 0.2s;
+    margin-left: 8px;
+  }
+
+  .search-sidebar-disclosure[open] .search-sidebar-summary-caret {
+    transform: rotate(-135deg);
+  }
+
+  @media (min-width: 1024px) {
+    .search-sidebar-summary {
+      display: none;
+    }
+  }
+
+  .search-sidebar-body {
+    padding: 4px 18px 14px;
+  }
+
+  @media (min-width: 1024px) {
+    .search-sidebar-body {
+      padding: 0;
+    }
+  }
+
+  .search-sidebar-section {
+    padding: 18px 0;
+    border-bottom: 1px solid #e8e6e0;
+  }
+
+  .search-sidebar-section:first-child {
+    padding-top: 4px;
+  }
+
+  .search-sidebar-section:last-child {
+    border-bottom: none;
+    padding-bottom: 4px;
+  }
+
+  .search-sidebar-section .overline {
+    margin-bottom: 10px;
+  }
+
+  .search-input-sidebar {
+    width: 100%;
+    background: #f6f5f0;
+    border: 1px solid #e8e6e0;
+    border-radius: 6px;
+    padding: 10px 12px 10px 34px;
+    font-size: 14px;
+  }
+
+  .type-segmented {
+    display: flex;
+    background: #f6f5f0;
+    border: 1px solid #e8e6e0;
+    border-radius: 6px;
+    padding: 3px;
+    width: 100%;
+    gap: 2px;
+  }
+
+  .type-segmented-option {
+    flex: 1;
+    text-align: center;
+    font-size: 12px;
+    padding: 6px 10px;
+    border-radius: 4px;
+    color: #7a7870;
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      color 0.15s;
+    white-space: nowrap;
+  }
+
+  .type-segmented input:checked + .type-segmented-option {
+    background: #ffffff;
+    color: #c23b22;
+    box-shadow: 0 1px 2px rgba(26, 25, 24, 0.08);
+  }
+
+  .type-segmented input:focus-visible + .type-segmented-option {
+    outline: 2px solid #c23b22;
+    outline-offset: 2px;
+  }
+
+  .facet-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 0;
+    font-size: 13px;
+    color: #4a4840;
+    cursor: pointer;
+    user-select: none;
+    line-height: 1.4;
+  }
+
+  .facet-row:hover {
+    color: #1a1918;
+  }
+
+  .facet-row input {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border: 1.5px solid #d0cec8;
+    background: #ffffff;
+    margin: 0 8px 0 0;
+    flex-shrink: 0;
+    position: relative;
+    top: 2px;
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background 0.15s;
+  }
+
+  .facet-row input[type="radio"] {
+    border-radius: 50%;
+  }
+
+  .facet-row input[type="checkbox"] {
+    border-radius: 3px;
+  }
+
+  .facet-row input:checked {
+    border-color: #c23b22;
+    background: #c23b22;
+  }
+
+  .facet-row input[type="radio"]:checked::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #ffffff;
+    transform: translate(-50%, -50%);
+  }
+
+  .facet-row input[type="checkbox"]:checked::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 3px;
+    width: 4px;
+    height: 8px;
+    border: solid #ffffff;
+    border-width: 0 1.5px 1.5px 0;
+    transform: rotate(45deg);
+  }
+
+  .facet-row-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: flex;
+    align-items: baseline;
+  }
+
+  .facet-row-count {
+    font-size: 12px;
+    color: #807e76;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .facet-row-disabled {
+    color: #b8b6ae;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .facet-row-disabled .facet-row-count {
+    color: #b8b6ae;
+  }
+
+  .facet-row-disabled input {
+    border-color: #e8e6e0;
+    background: #f6f5f0;
+  }
+
+  .sidebar-clear-btn {
+    font-size: 12px;
+    color: #7a7870;
+    background: transparent;
+    border: none;
+    padding: 14px 0 0;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    display: none;
+  }
+
+  .sidebar-clear-btn.is-visible {
+    display: inline-block;
+  }
+
+  .sidebar-clear-btn:hover {
+    color: #c23b22;
+  }
+
+  .filter-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px 12px;
+    padding: 20px 0 18px;
+    border-bottom: 1px solid #e8e6e0;
+    margin-bottom: 24px;
+    min-height: 52px;
+  }
+
+  .filter-summary-count {
+    font-family: "DM Serif Display", Georgia, serif;
+    font-size: 26px;
+    color: #1a1918;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .filter-summary-total {
+    font-size: 13px;
+    color: #807e76;
+    margin-left: 2px;
+  }
+
+  .filter-summary-sep {
+    display: inline-block;
+    width: 1px;
+    height: 18px;
+    background: #d0cec8;
+    margin: 0 4px;
+    align-self: center;
+  }
+
+  .filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: rgba(194, 59, 34, 0.08);
+    color: #c23b22;
+    border: 1px solid rgba(194, 59, 34, 0.14);
+    border-radius: 20px;
+    padding: 4px 4px 4px 12px;
+    font-size: 12px;
+    line-height: 1;
+  }
+
+  .filter-chip-remove {
+    background: transparent;
+    border: none;
+    color: #c23b22;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: background 0.12s;
+  }
+
+  .filter-chip-remove:hover {
+    background: rgba(194, 59, 34, 0.18);
+  }
+
+  .filter-summary-clear {
+    background: transparent;
+    border: none;
+    color: #7a7870;
+    font-size: 12px;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    padding: 0;
+    margin-left: auto;
+  }
+
+  .filter-summary-clear:hover {
+    color: #c23b22;
+  }
+
+  .results-swap {
+    transition: opacity 0.12s;
+  }
+
+  .results-swap.is-swapping {
+    opacity: 0.55;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
# Important Changes

- **Parser fixes**: Skip header rows in table-four, table-five, and key-value parsers that use `<td>`/`<th>` instead of proper headers, eliminating 20 garbage pardon records
- **Database schema**: Add nullable `pardons.slug` column with unique index and in-place migration support
- **Slug assignment**: Implement pure `assignSlugs()` function with collision resolution (base → base-date → base-date-type → base-id escalation chain)
- **Post-scrape pass**: Add `assignAllPardonSlugs()` to compute and persist slugs after all presidents are scraped
- **Content collection**: Expose `slug` field in loader and update all page consumers to read pre-computed slugs instead of recomputing
- **Result**: Build now produces 2329 pardon detail pages (up from 2316), recovering collision-lost pages with proper URL uniqueness
- **About page**: Add new about page with markdown-based content management