### PR TITLE
feat: update og image subtitle for clarity

### DIFF
--- a/src/pages/og/home.png.ts
+++ b/src/pages/og/home.png.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = async () => {
 
   const png = await renderOgImage({
     title: "Tracking Presidential Pardons",
-    subtitle: "More Money, More Pardons",
+    subtitle: "Pardons Granted by US Presidents Since 2000",
     stat: `${stats.totalGrants}`,
     statLabel: "Clemency Grants Tracked",
   });


### PR DESCRIPTION
Update the Open Graph image subtitle on the home page
from "More Money, More Pardons" to "Pardons Granted by
US Presidents Since 2000" to better reflect the actual
content and improve clarity for social media previews.