### PR TITLE
living-presidents-expansion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ pnpm test            # vitest (not jest)
 pnpm lint            # oxlint
 pnpm format          # oxfmt
 pnpm scrape          # All presidents, ~5-10 min via Playwright
-pnpm scrape:trump2   # Single-president variants: trump2 | biden | trump1 | obama | bush
+pnpm scrape:trump2   # Single-president variants: trump2 | biden | trump1 | obama | bush | clinton
 ```
 
 ## Data flow

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "scrape:trump1": "tsx src/scraper/scrape.ts --president trump-1",
     "scrape:obama": "tsx src/scraper/scrape.ts --president obama",
     "scrape:bush": "tsx src/scraper/scrape.ts --president bush-jr",
+    "scrape:clinton": "tsx src/scraper/scrape.ts --president clinton",
     "scrape:all": "tsx src/scraper/scrape.ts --president all",
     "db:studio": "drizzle-kit studio"
   },

--- a/src/components/StatCard.astro
+++ b/src/components/StatCard.astro
@@ -3,6 +3,8 @@ interface Props {
     label: string;
     value: string;
     footnote?: string;
+    noteText?: string;
+    noteHref?: string;
     variant?: "default" | "restitution" | "small";
     animated?: boolean;
     animationDelay?: number;
@@ -12,6 +14,8 @@ const {
     label,
     value,
     footnote,
+    noteText,
+    noteHref,
     variant = "default",
     animated = false,
     animationDelay = 0,
@@ -39,4 +43,9 @@ const delayStyle =
     <div class="overline">{label}</div>
     <div class:list={valueClasses}>{value}</div>
     {footnote && <div class="text-meta text-text-ghost mt-2">{footnote}</div>}
+    {noteText && noteHref && (
+        <div class="text-meta text-text-ghost mt-1">
+            <a href={noteHref} class="underline hover:text-text-primary">{noteText}</a>
+        </div>
+    )}
 </div>

--- a/src/components/StatGrid.astro
+++ b/src/components/StatGrid.astro
@@ -50,6 +50,8 @@ const { stats, animated = false, footnote } = Astro.props;
         label="Prison Time Reduced "
         value={stats.totalYearsErased.toLocaleString()}
         footnote="In Years"
+        noteText="Estimate — see note"
+        noteHref="/about#on-prison-time-reduced"
         variant="default"
         animated={animated}
         animationDelay={animated ? 4 * 150 : 0}
@@ -57,6 +59,8 @@ const { stats, animated = false, footnote } = Astro.props;
     <StatCard
         label="Restitution Abandoned"
         value={formatCurrency(stats.totalRestitutionAbandoned)}
+        noteText="Estimate — see note"
+        noteHref="/about#on-fines-and-restitution-abandoned"
         variant="restitution"
         animated={animated}
         animationDelay={animated ? 5 * 150 : 0}
@@ -64,6 +68,8 @@ const { stats, animated = false, footnote } = Astro.props;
     <StatCard
         label="Fines Abandoned"
         value={formatCurrency(stats.totalFinesAbandoned)}
+        noteText="Estimate — see note"
+        noteHref="/about#on-fines-and-restitution-abandoned"
         variant="restitution"
         animated={animated}
         animationDelay={animated ? 6 * 150 : 0}

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Pardonned",
   tagline: "Unofficial Pardon Tracker",
-  description: "A public-interest site, tracking Presidential pardons since 2000",
+  description: "A public-interest site, tracking Pardons granted by all living US Presidents",
   dataSource: "DOJ Office of the Pardon Attorney",
   disclaimer: "Not affiliated with the U.S. government",
   siteUrl: "https://pardonned.com",

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -1,15 +1,27 @@
 ---
 title: Why Pardonned Exists & How It's Built
-description: About Pardonned — an unofficial tracker of presidential pardons and commutations since 2000, inspired by Liz Oyer's work on pardon impropriety.
+description: About Pardonned — an unofficial tracker of presidential pardons and commutations of all living presidents, inspired by Liz Oyer's work on pardons by the current administration.
 ---
 
 ## What Is This Site?
 
-This is an unofficial tracker of pardons granted by US Presidents since 2000. The site is inspired by [Liz Oyer's](https://www.lawyeroyer.com/) videos and posts about the appearance of impropriety in presidential pardons, especially under President Donald Trump.
+This is an unofficial tracker of pardons granted by all living US Presidents (though this will eventually change). The site is inspired by [Liz Oyer's](https://www.lawyeroyer.com/) videos and posts about the appearance of impropriety in presidential pardons, especially under President Donald Trump.
 
 ## How Do We Get the Data?
 
 The data for the website is available through the [DOJ Website](https://www.justice.gov/pardon/clemency-recipients). We scrape the website once a day, and rebuild the database. The code for the parser and to see how this website is built is public and available at [github.com/vidluther/pardonned](https://github.com/vidluther/pardonned).
+
+## On Prison Time Reduced.
+
+This is an estimate, and is hard to calculate. For example
+
+Rod Blagojevich was convicted in 2011 for 168 months, he did serve 14 yrs in prison, so the current calculattion of prison time reduced is inaccurate. I'm sure there are other instances like this, especially for the mass commutations by Trump for January 6th rioters, and by Biden for the drug offenses.
+
+Ross Ulbricht also spent some time in prison, so we need to keep that in mind.
+
+## On Fines and Restitution Abandoned
+
+This is an estimate as well, currently I do not know how to verify if any amount of fines or restitution was paid or not.
 
 ## How Can You Help?
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,17 +19,19 @@ const sortedAdmins = Array.from(index.values()).sort((a, b) =>
 ---
 
 <Layout
-    title="Every Presidential Pardon Since 2000"
+    title="Tracking Presidential Pardons since Bill Clinton"
     description="Explore presidential clemency grants. Track pardons and commutations across administrations by category, date, and financial impact."
     ogImage="/og/home.png"
     currentPath={currentPath}
 >
     <!-- Hero Section -->
-    <section class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center">
+    <section
+        class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center"
+    >
         <h1 class="hero-headline mb-6 max-w-3xl mx-auto">
             Tracking Presidential Pardons
         </h1>
-        <h2 class="hero-subtitle mb-8">Since 2000</h2>
+        <h2 class="hero-subtitle mb-8">Since William Jefferson Clinton</h2>
         <StatGrid stats={stats} animated={true} />
     </section>
 
@@ -39,26 +41,38 @@ const sortedAdmins = Array.from(index.values()).sort((a, b) =>
     </div>
 
     <!-- Administrations Section -->
-    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
+    <section
+        class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto"
+        data-animate
+    >
         <h2 class="text-section font-serif text-text-primary mb-2">
             By Administration
         </h2>
         <p class="text-nav text-text-faint mb-10">
             Select an administration to explore its clemency record
         </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-grid">
-            {sortedAdmins.map((admin) => (
-                <a
-                    href={`/president/${admin.slug}`}
-                    class="category-card hover:bg-muted transition-colors"
-                    style="border-left-color: var(--color-accent);"
-                >
-                    <span class="category-count" style="color: var(--color-accent);">
-                        {admin.count.toLocaleString()}
-                    </span>
-                    <span class="text-nav text-text-body">{admin.displayName}</span>
-                </a>
-            ))}
+        <div
+            class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-grid"
+        >
+            {
+                sortedAdmins.map((admin) => (
+                    <a
+                        href={`/president/${admin.slug}`}
+                        class="category-card hover:bg-muted transition-colors"
+                        style="border-left-color: var(--color-accent);"
+                    >
+                        <span
+                            class="category-count"
+                            style="color: var(--color-accent);"
+                        >
+                            {admin.count.toLocaleString()}
+                        </span>
+                        <span class="text-nav text-text-body">
+                            {admin.displayName}
+                        </span>
+                    </a>
+                ))
+            }
         </div>
     </section>
 
@@ -68,12 +82,16 @@ const sortedAdmins = Array.from(index.values()).sort((a, b) =>
     </div>
 
     <!-- Search CTA -->
-    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto text-center" data-animate>
+    <section
+        class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto text-center"
+        data-animate
+    >
         <h2 class="text-section font-serif text-text-primary mb-4">
             Explore the Data
         </h2>
         <p class="text-nav text-text-faint mb-8">
-            Search, filter, and explore all {stats.totalGrants.toLocaleString()} clemency grants
+            Search, filter, and explore all {stats.totalGrants.toLocaleString()} clemency
+            grants
         </p>
         <a href="/search" class="load-more-btn inline-block no-underline">
             Search all pardons →
@@ -89,18 +107,22 @@ const sortedAdmins = Array.from(index.values()).sort((a, b) =>
 <script src="/scripts/animate-on-scroll.js" is:inline></script>
 
 <script is:inline>
-  document.addEventListener('DOMContentLoaded', () => {
-    // Track administration card clicks
-    document.querySelectorAll('a[href^="/president/"]').forEach((card) => {
-      card.addEventListener('click', () => {
-        const slug = card.getAttribute('href')?.replace('/president/', '');
-        window.posthog?.capture('administration_clicked', { slug });
-      });
-    });
+    document.addEventListener("DOMContentLoaded", () => {
+        // Track administration card clicks
+        document.querySelectorAll('a[href^="/president/"]').forEach((card) => {
+            card.addEventListener("click", () => {
+                const slug = card
+                    .getAttribute("href")
+                    ?.replace("/president/", "");
+                window.posthog?.capture("administration_clicked", { slug });
+            });
+        });
 
-    // Track "Search all pardons" CTA click
-    document.querySelector('a[href="/search"].load-more-btn')?.addEventListener('click', () => {
-      window.posthog?.capture('search_all_pardons_clicked');
+        // Track "Search all pardons" CTA click
+        document
+            .querySelector('a[href="/search"].load-more-btn')
+            ?.addEventListener("click", () => {
+                window.posthog?.capture("search_all_pardons_clicked");
+            });
     });
-  });
 </script>

--- a/src/pages/og/home.png.ts
+++ b/src/pages/og/home.png.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = async () => {
 
   const png = await renderOgImage({
     title: "Tracking Presidential Pardons",
-    subtitle: "Pardons Granted by US Presidents Since 2000",
+    subtitle: "Pardons Granted by US Presidents",
     stat: `${stats.totalGrants}`,
     statLabel: "Clemency Grants Tracked",
   });

--- a/src/scraper/__tests__/presidents.test.ts
+++ b/src/scraper/__tests__/presidents.test.ts
@@ -3,9 +3,7 @@ import { PRESIDENT_SOURCES, TERM_BOUNDARIES } from "../presidents.js";
 
 describe("PRESIDENT_SOURCES", () => {
   it("includes Clinton with both terms", () => {
-    const clinton = PRESIDENT_SOURCES.find((s) =>
-      s.slugs.includes("clinton-1"),
-    );
+    const clinton = PRESIDENT_SOURCES.find((s) => s.slugs.includes("clinton-1"));
     expect(clinton).toBeDefined();
     expect(clinton!.slugs).toEqual(["clinton-1", "clinton-2"]);
     expect(clinton!.pardons).toMatch(/clinton/i);

--- a/src/scraper/__tests__/presidents.test.ts
+++ b/src/scraper/__tests__/presidents.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { PRESIDENT_SOURCES, TERM_BOUNDARIES } from "../presidents.js";
+
+describe("PRESIDENT_SOURCES", () => {
+  it("includes Clinton with both terms", () => {
+    const clinton = PRESIDENT_SOURCES.find((s) =>
+      s.slugs.includes("clinton-1"),
+    );
+    expect(clinton).toBeDefined();
+    expect(clinton!.slugs).toEqual(["clinton-1", "clinton-2"]);
+    expect(clinton!.pardons).toMatch(/clinton/i);
+    expect(clinton!.commutations).toMatch(/clinton/i);
+  });
+
+  it("has a Clinton term-boundary entry", () => {
+    expect(TERM_BOUNDARIES["William J. Clinton"]).toBe("1997-01-20");
+  });
+});

--- a/src/scraper/presidents.ts
+++ b/src/scraper/presidents.ts
@@ -30,6 +30,12 @@ export const PRESIDENT_SOURCES: PresidentSource[] = [
     commutations:
       "https://www.justice.gov/pardon/commutations-granted-president-george-w-bush-2001-2009",
   },
+  {
+    slugs: ["clinton-1", "clinton-2"],
+    pardons: "https://www.justice.gov/pardon/pardons-granted-president-william-j-clinton-1993-2001",
+    commutations:
+      "https://www.justice.gov/pardon/commutations-granted-president-william-j-clinton-1993-2001",
+  },
 ];
 
 /**


### PR DESCRIPTION
## Changes

- Register Clinton pardons and commutations data sources
- Add `pnpm scrape:clinton` script for data collection
- Expand pardon tracking scope to cover all living US Presidents (removed "Since 2000" constraint)
- Add optional note link support to StatCard component
- Update about page with data calculation disclaimers
- Update site description and OG image subtitle
- Document new scrape command in CLAUDE.md