### PR TITLE
copy-database-to-public-directory

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,6 +85,9 @@ jobs:
           fi
           echo "Database size: $(du -h data/pardonned.db | cut -f1)"
 
+      - name: Copy database to public directory
+        run: cp data/pardonned.db public/pardonned.db
+
       - name: Build site
         env:
           PARDONNED_DB: ./data/pardonned.db

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pnpm-debug.log*
 
 # data files (produced by scraper, injected at build time)
 data/*.db
+public/*.db
 
 # local git worktrees
 .worktrees/

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -88,7 +88,11 @@ try {
       Data source: {siteConfig.dataSource} · {siteConfig.disclaimer}
     </p>
     <p class="text-meta text-text-ghost mt-1">
-      Last updated: {lastUpdated}
+      Last updated: {lastUpdated} · <a
+        href="/pardonned.db"
+        download
+        class="text-text-muted hover:text-text-primary transition-colors underline-offset-2 hover:underline"
+      >Click here to view the raw db for yourself</a>
     </p>
     <p class="text-meta text-text-ghost mt-1">
       Site built by <a


### PR DESCRIPTION
# Important Changes

- Copy generated pardoned database to public directory during build workflow, making it accessible as a static asset
- Update gitignore to exclude database files from public directory
- Add downloadable raw database link to footer for improved transparency and direct data access