### PR TITLE
add-date-filter-sidebar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -152,12 +152,13 @@ const recentEntries = Array.from(grantsByDate.entries())
                         <div
                             class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4 mb-1.5"
                         >
-                            <span
-                                class="timeline-date"
+                            <a
+                                class="timeline-date timeline-date-link no-underline"
+                                href={`/search?date=${entry.isoDate}`}
                                 data-iso-date={entry.isoDate}
                             >
                                 {entry.date}
-                            </span>
+                            </a>
                             <span class="timeline-grants-badge inline-block w-fit">
                                 {entry.grants}
                             </span>
@@ -171,9 +172,13 @@ const recentEntries = Array.from(grantsByDate.entries())
                                 />
                             ))}
                             {entry.overflow > 0 && (
-                                <span class="recent-overflow-note">
-                                    +{entry.overflow} more on this date
-                                </span>
+                                <a
+                                    class="recent-overflow-note no-underline"
+                                    href={`/search?date=${entry.isoDate}`}
+                                    data-iso-date={entry.isoDate}
+                                >
+                                    +{entry.overflow} more — view this date and earlier →
+                                </a>
                             )}
                         </div>
                     </div>
@@ -229,6 +234,28 @@ const recentEntries = Array.from(grantsByDate.entries())
             .querySelector('a[href="/search"].load-more-btn')
             ?.addEventListener("click", () => {
                 window.posthog?.capture("search_all_pardons_clicked");
+            });
+
+        // Track Recent section date label clicks
+        document
+            .querySelectorAll("a.timeline-date-link[data-iso-date]")
+            .forEach((link) => {
+                link.addEventListener("click", () => {
+                    window.posthog?.capture("recent_date_clicked", {
+                        date: link.getAttribute("data-iso-date"),
+                    });
+                });
+            });
+
+        // Track Recent section overflow link clicks
+        document
+            .querySelectorAll("a.recent-overflow-note[data-iso-date]")
+            .forEach((link) => {
+                link.addEventListener("click", () => {
+                    window.posthog?.capture("recent_overflow_clicked", {
+                        date: link.getAttribute("data-iso-date"),
+                    });
+                });
             });
     });
 </script>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -180,6 +180,16 @@ const sortedCategories = Object.entries(categoryCounts)
             </div>
 
             <div class="search-sidebar-section">
+              <p class="overline">Date (or earlier)</p>
+              <label for="date-input" class="sr-only">Show grants on this date or earlier</label>
+              <input
+                id="date-input"
+                type="date"
+                class="date-input-sidebar"
+              />
+            </div>
+
+            <div class="search-sidebar-section">
               <p class="overline">Grant Type</p>
               <fieldset id="type-segmented" class="type-segmented">
                 <legend class="sr-only">Filter by grant type</legend>
@@ -258,6 +268,7 @@ const sortedCategories = Object.entries(categoryCounts)
       const TOTAL = grants.length;
 
       const searchInput = document.getElementById('search-input');
+      const dateInput = document.getElementById('date-input');
       const typeSegmented = document.getElementById('type-segmented');
       const presidentFacets = document.getElementById('president-facets');
       const categoryFacets = document.getElementById('category-facets');
@@ -289,6 +300,7 @@ const sortedCategories = Object.entries(categoryCounts)
       const state = {
         search: '',
         type: '',
+        date: '',
         president: 'all',
         categories: new Set(),
         page: 1,
@@ -296,6 +308,13 @@ const sortedCategories = Object.entries(categoryCounts)
 
       function formatCategoryName(key) {
         return key.replace(/\b\w/g, (c) => c.toUpperCase());
+      }
+
+      function formatDateLong(iso) {
+        const [y, m, d] = iso.split('-');
+        return new Date(Number(y), Number(m) - 1, Number(d)).toLocaleDateString('en-US', {
+          year: 'numeric', month: 'long', day: 'numeric',
+        });
       }
 
       function formatRestitution(value) {
@@ -320,6 +339,9 @@ const sortedCategories = Object.entries(categoryCounts)
           }
         }
         if (!skip?.type && state.type && grant.clemencyType !== state.type) {
+          return false;
+        }
+        if (!skip?.date && state.date && grant.grantDate > state.date) {
           return false;
         }
         if (!skip?.president && state.president !== 'all' && grant.administrationSlug !== state.president) {
@@ -421,6 +443,12 @@ const sortedCategories = Object.entries(categoryCounts)
           chips.push({
             label: state.type === 'pardon' ? 'Pardon' : 'Commutation',
             action: 'clear-type',
+          });
+        }
+        if (state.date) {
+          chips.push({
+            label: 'On or before ' + formatDateLong(state.date),
+            action: 'clear-date',
           });
         }
         if (state.president !== 'all') {
@@ -649,6 +677,7 @@ const sortedCategories = Object.entries(categoryCounts)
         const params = new URLSearchParams();
         if (state.search) params.set('q', state.search);
         if (state.type) params.set('type', state.type);
+        if (state.date) params.set('date', state.date);
         if (state.president !== 'all') params.set('president', state.president);
         if (state.categories.size > 0) params.set('categories', Array.from(state.categories).join(','));
         if (state.page > 1) params.set('page', String(state.page));
@@ -671,6 +700,10 @@ const sortedCategories = Object.entries(categoryCounts)
 
         const typeRadio = findInputByValue(typeSegmented, 'type', state.type);
         if (typeRadio && !typeRadio.checked) typeRadio.checked = true;
+
+        if (dateInput && dateInput.value !== state.date) {
+          dateInput.value = state.date;
+        }
 
         const desktopPres = findInputByValue(presidentFacets, 'president', state.president);
         if (desktopPres && !desktopPres.checked) desktopPres.checked = true;
@@ -704,17 +737,20 @@ const sortedCategories = Object.entries(categoryCounts)
         const priorFilterCount =
           (state.search ? 1 : 0) +
           (state.type ? 1 : 0) +
+          (state.date ? 1 : 0) +
           (state.president !== 'all' ? 1 : 0) +
           state.categories.size;
 
         state.search = '';
         state.type = '';
+        state.date = '';
         state.president = 'all';
         state.categories.clear();
         state.page = 1;
 
         if (searchInput) searchInput.value = '';
         if (mobileSearchInput) mobileSearchInput.value = '';
+        if (dateInput) dateInput.value = '';
 
         applyState();
         window.posthog?.capture('search_filters_cleared', {
@@ -738,6 +774,7 @@ const sortedCategories = Object.entries(categoryCounts)
               has_results: resultsCount > 0,
               active_filters: {
                 type: state.type || null,
+                date: state.date || null,
                 president: state.president !== 'all' ? state.president : null,
                 categories_count: state.categories.size,
               },
@@ -760,6 +797,17 @@ const sortedCategories = Object.entries(categoryCounts)
           }
         }
       });
+
+      if (dateInput) {
+        dateInput.addEventListener('change', (e) => {
+          state.date = e.target.value;
+          state.page = 1;
+          applyState();
+          if (state.date) {
+            window.posthog?.capture('date_filter_applied', { date: state.date });
+          }
+        });
+      }
 
       presidentFacets.addEventListener('change', (e) => {
         const t = e.target;
@@ -811,6 +859,9 @@ const sortedCategories = Object.entries(categoryCounts)
           if (mobileSearchInput) mobileSearchInput.value = '';
         } else if (action === 'clear-type') {
           state.type = '';
+        } else if (action === 'clear-date') {
+          state.date = '';
+          if (dateInput) dateInput.value = '';
         } else if (action === 'clear-president') {
           state.president = 'all';
         } else if (action && action.startsWith('clear-category:')) {
@@ -844,6 +895,7 @@ const sortedCategories = Object.entries(categoryCounts)
           has_active_filters:
             Boolean(state.search) ||
             Boolean(state.type) ||
+            Boolean(state.date) ||
             state.president !== 'all' ||
             state.categories.size > 0,
         });
@@ -901,6 +953,12 @@ const sortedCategories = Object.entries(categoryCounts)
         state.type = typeParam;
         const radio = findInputByValue(typeSegmented, 'type', typeParam);
         if (radio) radio.checked = true;
+      }
+
+      const dateParam = urlParams.get('date');
+      if (dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
+        state.date = dateParam;
+        if (dateInput) dateInput.value = dateParam;
       }
 
       const presParam = urlParams.get('president');

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -192,6 +192,11 @@
     font-size: 13px;
     color: #7a7870;
     font-style: italic;
+    transition: color 0.15s ease;
+  }
+
+  a.recent-overflow-note:hover {
+    color: #1a1918;
   }
 
   .badge {
@@ -504,6 +509,15 @@
     .timeline-date {
       min-width: 110px;
     }
+  }
+
+  .timeline-date-link {
+    display: inline-block;
+    transition: color 0.15s ease;
+  }
+
+  .timeline-date-link:hover {
+    color: #1a1918;
   }
 
   .timeline-grants-badge {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -689,6 +689,17 @@
     font-size: 14px;
   }
 
+  .date-input-sidebar {
+    width: 100%;
+    background: #f6f5f0;
+    border: 1px solid #e8e6e0;
+    border-radius: 6px;
+    padding: 10px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    color: inherit;
+  }
+
   .type-segmented {
     display: flex;
     background: #f6f5f0;


### PR DESCRIPTION
- Add a date filter to the search sidebar, including matching styling and support for filtering grants by the selected date or earlier
- Persist the selected date in search state and the URL so dated searches are shareable and restorable
- Show the active date filter as a removable chip and clear it alongside other filters
- Include the selected date in search analytics payloads
- Make Recent timeline date labels and overflow notes link to the corresponding dated search view
- Add hover styles and click tracking for Recent date-based links to improve usability and analytics

Closes #32 and #33