### PR TITLE
implement-claude-redesign

### DIFF
--- a/.posthog-events.json
+++ b/.posthog-events.json
@@ -1,0 +1,152 @@
+[
+  {
+    "event": "header_nav_clicked",
+    "description": "Click on a top header navigation link (desktop or mobile drawer).",
+    "file": "src/components/Header.astro",
+    "properties": ["link", "label", "source", "from_path"]
+  },
+  {
+    "event": "mobile_nav_toggled",
+    "description": "Mobile hamburger menu opened or closed.",
+    "file": "src/components/Header.astro",
+    "properties": ["state", "from_path"]
+  },
+  {
+    "event": "footer_link_clicked",
+    "description": "Click on any link in the site footer (nav duplicate, social icon, raw DB download, author byline).",
+    "file": "src/components/Footer.astro",
+    "properties": ["kind", "label", "href", "from_path"]
+  },
+  {
+    "event": "administration_clicked",
+    "description": "Navigation to a /president/<slug> page from a list or table row.",
+    "file": "src/pages/index.astro, src/pages/all-presidents.astro, src/pages/recent.astro",
+    "properties": ["slug", "source"]
+  },
+  {
+    "event": "recent_date_clicked",
+    "description": "Click on a homepage newswire row to open a pardon detail.",
+    "file": "src/pages/index.astro",
+    "properties": ["date", "slug", "source"]
+  },
+  {
+    "event": "view_all_recent_clicked",
+    "description": "Homepage newswire 'View all recent →' CTA.",
+    "file": "src/pages/index.astro",
+    "properties": ["source"]
+  },
+  {
+    "event": "restitution_leaderboard_clicked",
+    "description": "Homepage restitution leaderboard row click.",
+    "file": "src/pages/index.astro",
+    "properties": ["slug", "position", "restitution", "source"]
+  },
+  {
+    "event": "category_clicked",
+    "description": "Click on an offense-category row (homepage breakdown or president page composition).",
+    "file": "src/pages/index.astro, src/pages/president/[slug].astro",
+    "properties": ["category", "source"]
+  },
+  {
+    "event": "search_all_pardons_clicked",
+    "description": "CTA that links to the search page from the homepage source band or a president page.",
+    "file": "src/pages/index.astro, src/pages/president/[slug].astro",
+    "properties": ["source"]
+  },
+  {
+    "event": "pardon_detail_viewed",
+    "description": "Pardon detail page mounted (acts as the canonical detail-view event).",
+    "file": "src/pages/pardon/details/[slug].astro",
+    "properties": ["name", "clemency_type", "offense_category", "slug"]
+  },
+  {
+    "event": "source_document_clicked",
+    "description": "Click on the linked DOJ warrant PDF on a pardon detail page.",
+    "file": "src/pages/pardon/details/[slug].astro",
+    "properties": ["slug", "name"]
+  },
+  {
+    "event": "pardon_neighbor_clicked",
+    "description": "Prev/next pagination between pardon detail pages within an administration.",
+    "file": "src/pages/pardon/details/[slug].astro",
+    "properties": ["from_slug", "to_slug", "direction"]
+  },
+  {
+    "event": "administration_neighbor_clicked",
+    "description": "Prev/next pagination between president pages chronologically.",
+    "file": "src/pages/president/[slug].astro",
+    "properties": ["from_slug", "to_slug", "direction"]
+  },
+  {
+    "event": "all_presidents_sorted",
+    "description": "Sortable column header click on the all-presidents comparison table.",
+    "file": "src/pages/all-presidents.astro",
+    "properties": ["column", "direction"]
+  },
+  {
+    "event": "recent_month_loaded",
+    "description": "Recent feed 'Load older' button revealed the next month group.",
+    "file": "src/pages/recent.astro",
+    "properties": ["month", "rank"]
+  },
+  {
+    "event": "recent_entry_clicked",
+    "description": "Click on a row in the recent feed (excludes the inner president-link click).",
+    "file": "src/pages/recent.astro",
+    "properties": ["slug", "date", "source"]
+  },
+  {
+    "event": "timeline_name_clicked",
+    "description": "Click on a recipient name chip inside the Timeline component (currently rendered on president pages).",
+    "file": "src/components/Timeline.astro",
+    "properties": ["name", "slug", "source", "from_path"]
+  },
+  {
+    "event": "search_performed",
+    "description": "Debounced fire after the user types in the search box and matches > 0 (debounce 600ms).",
+    "file": "src/pages/search.astro",
+    "properties": ["query", "results_count", "has_results", "active_filters"]
+  },
+  {
+    "event": "type_filter_applied",
+    "description": "Search type dropdown changed to pardon or commutation.",
+    "file": "src/pages/search.astro",
+    "properties": ["type"]
+  },
+  {
+    "event": "category_filter_applied",
+    "description": "Search category dropdown changed; fires once for the unset of the prior value and once for the new value.",
+    "file": "src/pages/search.astro",
+    "properties": ["category", "checked"]
+  },
+  {
+    "event": "president_filter_applied",
+    "description": "Search president dropdown changed to a non-'all' value.",
+    "file": "src/pages/search.astro",
+    "properties": ["president", "source"]
+  },
+  {
+    "event": "search_result_clicked",
+    "description": "Click on a result row in the search results table.",
+    "file": "src/pages/search.astro",
+    "properties": ["slug", "query", "position", "total_results", "page", "has_active_filters"]
+  },
+  {
+    "event": "search_filters_cleared",
+    "description": "Filters cleared via the 'Clear all' button or by removing an individual pill.",
+    "file": "src/pages/search.astro",
+    "properties": ["source", "filter_count", "filter_type"]
+  },
+  {
+    "event": "search_page_changed",
+    "description": "Search results pagination — prev, next, or page-number button.",
+    "file": "src/pages/search.astro",
+    "properties": ["from_page", "to_page", "total_pages"]
+  },
+  {
+    "event": "$exception",
+    "description": "Uncaught JS error or unhandled promise rejection captured globally. Forwarded via posthog.captureException from window error/unhandledrejection listeners; also enabled by autocapture defaults.",
+    "file": "src/components/PostHog.astro",
+    "properties": ["$exception_message", "$exception_type", "$exception_stack_trace_raw"]
+  }
+]

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,26 @@
+# Cloudflare Pages redirects.
+# Format: /from /to STATUS
+#
+# These graceful 301s catch guessable wrong URLs that aren't real routes
+# but are plausible enough that visitors (or external links) might try them.
+# Real routes:
+#   /search                    — search page
+#   /pardon/details/<slug>     — single grant detail
+#   /all-presidents            — cross-administration table
+#   /recent                    — recent grants feed (HTML)
+#   /recent.xml                — Atom feed
+
+# Plural-form guesses for the search page
+/pardons         /search                       301
+
+# Handoff-doc-implied detail URL → real detail URL
+/pardons/:slug   /pardon/details/:slug         301
+
+# "Presidents" plural → all-presidents page
+/presidents      /all-presidents               301
+
+# Common feed-discovery paths → Atom feed
+/feed            /recent.xml                   301
+/rss             /recent.xml                   301
+/feed.xml        /recent.xml                   301
+/atom.xml        /recent.xml                   301

--- a/src/components/CategoryBadge.astro
+++ b/src/components/CategoryBadge.astro
@@ -1,4 +1,6 @@
 ---
+import { getCategoryColor } from "../lib/category-colors";
+
 interface Props {
   category: string;
   label?: string;
@@ -6,18 +8,7 @@ interface Props {
 
 const { category, label } = Astro.props;
 
-const categoryColors: Record<string, string> = {
-  fraud: "#8A6B1E",
-  "drug offense": "#3A6A4A",
-  firearms: "#C23B22",
-  "FACE act": "#B8652A",
-  "financial crime": "#2A6A7A",
-  "violent crime": "#6A4B7A",
-  immigration: "#7A6A3A",
-  other: "#7A7870",
-};
-
-const color = categoryColors[category] ?? "#7A7870";
+const color = getCategoryColor(category);
 
 function formatCategoryName(key: string): string {
   return key.replace(/\b\w/g, (c) => c.toUpperCase());

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -51,6 +51,8 @@ try {
         {mainNavigation.map((item) => (
           <a
             href={item.href}
+            data-footer-kind="nav"
+            data-footer-label={item.label}
             class="text-nav text-text-muted hover:text-text-primary transition-colors"
           >
             {item.label}
@@ -68,6 +70,8 @@ try {
           target="_blank"
           aria-label={`${link.label} — ${link.handle}`}
           title={link.handle}
+          data-footer-kind="social"
+          data-footer-label={link.label}
           class="inline-flex items-center justify-center p-2 rounded-md text-text-muted hover:text-text-primary hover:bg-muted transition-colors"
         >
           <svg
@@ -91,6 +95,8 @@ try {
       Last updated: {lastUpdated} · <a
         href="/pardonned.db"
         download
+        data-footer-kind="db_download"
+        data-footer-label="raw_db"
         class="text-text-muted hover:text-text-primary transition-colors underline-offset-2 hover:underline"
       >Click here to view the raw db for yourself</a>
     </p>
@@ -99,8 +105,23 @@ try {
         href="https://luther.io"
         rel="author noopener"
         target="_blank"
+        data-footer-kind="author"
+        data-footer-label="vid_luther"
         class="text-text-muted hover:text-text-primary transition-colors underline-offset-2 hover:underline"
       >Vid Luther</a> and AI
     </p>
   </div>
 </footer>
+
+<script is:inline>
+  document.querySelector('footer')?.addEventListener('click', (e) => {
+    const link = e.target instanceof Element ? e.target.closest('a[data-footer-kind]') : null;
+    if (!link) return;
+    window.posthog?.capture('footer_link_clicked', {
+      kind: link.getAttribute('data-footer-kind'),
+      label: link.getAttribute('data-footer-label'),
+      href: link.getAttribute('href'),
+      from_path: window.location.pathname,
+    });
+  });
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -26,6 +26,9 @@ const { currentPath = "/" } = Astro.props;
         return (
           <a
             href={item.href}
+            data-nav-link={item.href}
+            data-nav-label={item.label}
+            data-nav-source="header_desktop"
             class:list={[
               "text-nav transition-colors pb-0.5",
               isActive
@@ -61,6 +64,9 @@ const { currentPath = "/" } = Astro.props;
       return (
         <a
           href={item.href}
+          data-nav-link={item.href}
+          data-nav-label={item.label}
+          data-nav-source="header_mobile"
           class:list={[
             "text-nav transition-colors py-2",
             isActive
@@ -85,6 +91,10 @@ const { currentPath = "/" } = Astro.props;
       nav.classList.remove('is-open');
       toggle.setAttribute('aria-expanded', 'false');
       toggle.focus();
+      window.posthog?.capture('mobile_nav_toggled', {
+        state: 'close',
+        from_path: window.location.pathname,
+      });
     }
 
     function openNav() {
@@ -92,6 +102,10 @@ const { currentPath = "/" } = Astro.props;
       toggle.setAttribute('aria-expanded', 'true');
       const firstLink = nav.querySelector('a');
       if (firstLink) firstLink.focus();
+      window.posthog?.capture('mobile_nav_toggled', {
+        state: 'open',
+        from_path: window.location.pathname,
+      });
     }
 
     toggle.addEventListener('click', () => {
@@ -107,6 +121,17 @@ const { currentPath = "/" } = Astro.props;
       if (e.key === 'Escape' && nav.classList.contains('is-open')) {
         closeNav();
       }
+    });
+
+    document.querySelectorAll('a[data-nav-link]').forEach((link) => {
+      link.addEventListener('click', () => {
+        window.posthog?.capture('header_nav_clicked', {
+          link: link.getAttribute('data-nav-link'),
+          label: link.getAttribute('data-nav-label'),
+          source: link.getAttribute('data-nav-source'),
+          from_path: window.location.pathname,
+        });
+      });
     });
   });
 </script>

--- a/src/components/MoneyFigure.astro
+++ b/src/components/MoneyFigure.astro
@@ -1,0 +1,79 @@
+---
+/**
+ * Bold-redesign money figure. Display-serif amount in --accent (or
+ * --text-ghost when muted) with an optional caption-grey label.
+ *
+ * Used by:
+ * - homepage number wall (sizeClass="text-display-lg")
+ * - homepage by-administration strip (sizeClass="text-section")
+ * - homepage restitution leaderboard (sizeClass="text-display")
+ * - detail-page money strip (#39)
+ * - all-presidents table (#43)
+ *
+ * The component takes a pre-formatted `value` string so the call site
+ * controls compact-vs-precise formatting (use `formatCompactMoney`
+ * from `src/lib/format.ts` for display-scale, or `Intl.NumberFormat`
+ * for row-level precision).
+ */
+interface Props {
+  /** Pre-formatted display string, e.g. "$1.47B", "—", "$0". */
+  value: string;
+  /** Optional caption beneath the value. */
+  label?: string;
+  /** Tailwind text-size class. Defaults to text-display-lg (64px). */
+  sizeClass?: string;
+  /** When true, render in --accent color. Default true. */
+  accent?: boolean;
+  /** When true, render in --text-ghost (overrides accent). For zero/null. */
+  muted?: boolean;
+  /** Right-align the value (used in tabular contexts). */
+  align?: "left" | "right";
+  /** Extra utility classes for the wrapper. */
+  class?: string;
+}
+
+const {
+  value,
+  label,
+  sizeClass = "text-display-lg",
+  accent = true,
+  muted = false,
+  align = "left",
+  class: className = "",
+} = Astro.props;
+
+const colorClass = muted
+  ? "text-text-ghost"
+  : accent
+    ? "text-accent"
+    : "text-text-primary";
+const alignClass = align === "right" ? "text-right" : "text-left";
+---
+
+<div class:list={["money-figure", alignClass, className]}>
+  <div
+    class:list={[
+      sizeClass,
+      "font-serif tabular-nums leading-none tracking-tight",
+      colorClass,
+    ]}
+  >
+    {value}
+  </div>
+  {
+    label && (
+      <div class="money-figure-label text-text-faint">
+        {label}
+      </div>
+    )
+  }
+</div>
+
+<style>
+  .money-figure-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-top: 6px;
+  }
+</style>

--- a/src/components/PostHog.astro
+++ b/src/components/PostHog.astro
@@ -4,9 +4,16 @@
 ---
 <script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN, apiHost: import.meta.env.PUBLIC_POSTHOG_HOST }}>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  // disable_session_recording MUST stay true — replays are billed by minute and out of budget for this project
   posthog.init(apiKey || '', {
-    api_host: apiHost || '',
+    api_host: apiHost || 'https://us.i.posthog.com',
     defaults: '2026-01-30',
     disable_session_recording: true,
   })
+  window.addEventListener('error', (e) => {
+    window.posthog?.captureException?.(e.error || new Error(e.message));
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    window.posthog?.captureException?.(e.reason instanceof Error ? e.reason : new Error(String(e.reason)));
+  });
 </script>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,0 +1,61 @@
+---
+/**
+ * Bold-redesign section masthead. Used to introduce major sections on
+ * the homepage, search, president, all-presidents, and recent pages.
+ *
+ * Pattern: 2px top border (--rule-emphasis), 1.2fr / 1fr two-column grid
+ * with title on the left and deck on the right, baseline-aligned.
+ * Collapses to a single column on mobile.
+ */
+interface Props {
+  title: string;
+  deck?: string;
+  /** Extra utility classes for the wrapper. */
+  class?: string;
+}
+
+const { title, deck, class: className = "" } = Astro.props;
+---
+
+<div class:list={["section-header", className]}>
+  <h2 class="section-title font-serif text-text-primary">{title}</h2>
+  {deck && <p class="section-deck text-text-secondary">{deck}</p>}
+</div>
+
+<style>
+  .section-header {
+    display: grid;
+    grid-template-columns: 1.2fr 1fr;
+    gap: 56px;
+    align-items: baseline;
+    border-top: var(--rule-emphasis);
+    padding: 28px 0;
+  }
+
+  .section-title {
+    font-size: 42px;
+    line-height: 1.05;
+    letter-spacing: -0.015em;
+    max-width: 720px;
+    margin: 0;
+  }
+
+  .section-deck {
+    font-size: 14px;
+    max-width: 540px;
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .section-header {
+      grid-template-columns: 1fr;
+      gap: 12px;
+      padding: 20px 0;
+    }
+
+    .section-title {
+      font-size: 30px;
+    }
+  }
+</style>

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -47,10 +47,14 @@ const { entries } = Astro.props;
 
 <script is:inline>
   document.querySelector('.timeline-container')?.addEventListener('click', (e) => {
-    const chip = e.target.closest('a.name-chip-link');
+    const chip = e.target instanceof Element ? e.target.closest('a.name-chip-link') : null;
     if (!chip) return;
+    const href = chip.getAttribute('href') || '';
     window.posthog?.capture('timeline_name_clicked', {
       name: chip.textContent?.trim(),
+      slug: href.split('/').pop() || null,
+      source: 'timeline',
+      from_path: window.location.pathname,
     });
   });
 </script>

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -7,6 +7,7 @@ export interface NavItem {
 export const mainNavigation: NavItem[] = [
   { label: "Home", href: "/" },
   { label: "Search", href: "/search" },
+  { label: "Presidents", href: "/all-presidents" },
   { label: "Recent", href: "/recent" },
   { label: "About", href: "/about" },
 ];

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -7,6 +7,7 @@ export interface NavItem {
 export const mainNavigation: NavItem[] = [
   { label: "Home", href: "/" },
   { label: "Search", href: "/search" },
+  { label: "Recent", href: "/recent" },
   { label: "About", href: "/about" },
 ];
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,6 +48,15 @@ const metaDescription = truncateText(description, 160);
 
         <SeoHead title={fullTitle} description={description} ogImage={ogImage} />
 
+        {currentPath.replace(/\/$/, "") === "/recent" && (
+            <link
+                rel="alternate"
+                type="application/atom+xml"
+                title="Pardonned — Recent Clemency Grants"
+                href={`${siteConfig.siteUrl}/recent.xml`}
+            />
+        )}
+
         <!-- Google Fonts - DM Sans + DM Serif Display -->
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/lib/__tests__/atom-feed.test.ts
+++ b/src/lib/__tests__/atom-feed.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { buildAtomFeed, type AtomEntry } from "../atom-feed";
+
+const baseOptions = {
+  siteUrl: "https://pardonned.com",
+  feedTitle: "Pardonned — Recent Clemency Grants",
+  feedSubtitle: "A test feed",
+  authorName: "Pardonned",
+};
+
+function makeEntry(overrides: Partial<AtomEntry["data"]> = {}): AtomEntry {
+  return {
+    id: overrides.id ?? "1",
+    data: {
+      id: "1",
+      slug: "test-recipient",
+      administration_slug: "trump-2",
+      grant_date: "2025-03-28",
+      clemency_type: "pardon",
+      offense: "Securities fraud",
+      offense_category: "fraud",
+      district: "S.D.N.Y.",
+      warrant_url: null,
+      source_url: null,
+      recipient_name: "Test Recipient",
+      sentence_in_months: null,
+      fine: null,
+      restitution: null,
+      original_sentence: null,
+      president_name: "Donald J. Trump",
+      term_number: 2,
+      term_start_date: "2025-01-20",
+      term_end_date: null,
+      ...overrides,
+    },
+  };
+}
+
+describe("buildAtomFeed", () => {
+  it("produces a well-formed Atom feed with root element and required headers", () => {
+    const xml = buildAtomFeed([makeEntry()], baseOptions);
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="utf-8"\?>/);
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain("</feed>");
+    expect(xml).toContain("<id>https://pardonned.com/recent.xml</id>");
+    expect(xml).toContain("<title>Pardonned — Recent Clemency Grants</title>");
+    expect(xml).toContain('<link rel="self" type="application/atom+xml" href="https://pardonned.com/recent.xml"/>');
+    expect(xml).toContain('<link rel="alternate" type="text/html" href="https://pardonned.com/recent"/>');
+  });
+
+  it("sorts entries by grant_date desc and applies the default limit of 50", () => {
+    const entries = Array.from({ length: 60 }, (_, i) => {
+      const month = String((i % 12) + 1).padStart(2, "0");
+      const day = String((i % 28) + 1).padStart(2, "0");
+      return makeEntry({
+        slug: `recipient-${i}`,
+        recipient_name: `Recipient ${i}`,
+        grant_date: `2024-${month}-${day}`,
+      });
+    });
+    const xml = buildAtomFeed(entries, baseOptions);
+    const matches = xml.match(/<entry>/g);
+    expect(matches?.length).toBe(50);
+  });
+
+  it("respects a custom limit", () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      makeEntry({ slug: `r-${i}`, grant_date: `2024-01-${String(i + 1).padStart(2, "0")}` }),
+    );
+    const xml = buildAtomFeed(entries, { ...baseOptions, limit: 3 });
+    expect((xml.match(/<entry>/g) ?? []).length).toBe(3);
+  });
+
+  it("orders entries newest-first", () => {
+    const entries = [
+      makeEntry({ slug: "older", grant_date: "2024-01-15", recipient_name: "Older" }),
+      makeEntry({ slug: "newest", grant_date: "2025-12-31", recipient_name: "Newest" }),
+      makeEntry({ slug: "middle", grant_date: "2025-06-01", recipient_name: "Middle" }),
+    ];
+    const xml = buildAtomFeed(entries, baseOptions);
+    const newestPos = xml.indexOf("Newest");
+    const middlePos = xml.indexOf("Middle");
+    const olderPos = xml.indexOf("Older");
+    expect(newestPos).toBeGreaterThan(0);
+    expect(newestPos).toBeLessThan(middlePos);
+    expect(middlePos).toBeLessThan(olderPos);
+  });
+
+  it("includes RFC 3339 timestamps for published and updated", () => {
+    const xml = buildAtomFeed([makeEntry({ grant_date: "2025-03-28" })], baseOptions);
+    expect(xml).toContain("<published>2025-03-28T12:00:00Z</published>");
+    expect(xml).toContain("<updated>2025-03-28T12:00:00Z</updated>");
+  });
+
+  it("uses the most recent grant_date as the feed's <updated>", () => {
+    const entries = [
+      makeEntry({ slug: "a", grant_date: "2024-01-01" }),
+      makeEntry({ slug: "b", grant_date: "2025-06-15" }),
+      makeEntry({ slug: "c", grant_date: "2024-12-01" }),
+    ];
+    const xml = buildAtomFeed(entries, baseOptions);
+    // The first <updated> in the feed (after the channel-level metadata) should be the feed-level one
+    const feedUpdatedMatch = xml.match(/<updated>(.*?)<\/updated>/);
+    expect(feedUpdatedMatch?.[1]).toBe("2025-06-15T12:00:00Z");
+  });
+
+  it("links each entry to its detail page using the slug", () => {
+    const xml = buildAtomFeed([makeEntry({ slug: "paul-manafort" })], baseOptions);
+    expect(xml).toContain('<link rel="alternate" type="text/html" href="https://pardonned.com/pardon/details/paul-manafort"/>');
+  });
+
+  it("uses a stable tag: URI for entry id", () => {
+    const xml = buildAtomFeed([makeEntry({ slug: "paul-manafort", grant_date: "2020-12-23" })], baseOptions);
+    expect(xml).toContain("<id>tag:pardonned.com,2020-12-23:pardon-paul-manafort</id>");
+  });
+
+  it("titles entries with recipient name + clemency-type label", () => {
+    const xml = buildAtomFeed(
+      [
+        makeEntry({ recipient_name: "Paul J. Manafort", clemency_type: "pardon" }),
+        makeEntry({ slug: "rita", recipient_name: "Rita Crundwell", clemency_type: "commutation" }),
+      ],
+      baseOptions,
+    );
+    expect(xml).toContain("<title>Paul J. Manafort — Pardon</title>");
+    expect(xml).toContain("<title>Rita Crundwell — Commutation</title>");
+  });
+
+  it("escapes XML special characters in recipient_name, offense, and slug", () => {
+    const xml = buildAtomFeed(
+      [
+        makeEntry({
+          slug: "test-slug",
+          recipient_name: 'Smith & Jones <"the partners">',
+          offense: "Bank fraud & wire fraud",
+        }),
+      ],
+      baseOptions,
+    );
+    expect(xml).toContain("Smith &amp; Jones &lt;&quot;the partners&quot;&gt;");
+    expect(xml).toContain("Bank fraud &amp; wire fraud");
+    // Ensure no unescaped & or < survived in the entry payload
+    expect(xml).not.toMatch(/Smith & Jones/);
+  });
+
+  it("uses the (First Term) / (Second Term) suffix for multi-term presidents", () => {
+    const entries = [
+      makeEntry({
+        slug: "trump-2-grant",
+        president_name: "Donald J. Trump",
+        term_number: 2,
+        recipient_name: "Person A",
+      }),
+      makeEntry({
+        slug: "trump-1-grant",
+        president_name: "Donald J. Trump",
+        term_number: 1,
+        recipient_name: "Person B",
+      }),
+      makeEntry({
+        slug: "biden-grant",
+        president_name: "Joseph R. Biden",
+        term_number: 1,
+        recipient_name: "Person C",
+      }),
+    ];
+    const xml = buildAtomFeed(entries, baseOptions);
+    expect(xml).toContain("Donald J. Trump (Second Term)");
+    expect(xml).toContain("Donald J. Trump (First Term)");
+    // Single-term president has no suffix
+    expect(xml).toContain("<author><name>Joseph R. Biden</name></author>");
+  });
+
+  it("renders an empty but well-formed feed when there are no entries", () => {
+    const xml = buildAtomFeed([], baseOptions);
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain("</feed>");
+    expect((xml.match(/<entry>/g) ?? []).length).toBe(0);
+    // Feed-level <updated> should still be present (falls back to "now" rather than blank)
+    expect(xml).toMatch(/<updated>[\d\-T:.Z]+<\/updated>/);
+  });
+
+  it("includes a summary with clemency type, recipient, administration, and offense", () => {
+    const xml = buildAtomFeed(
+      [
+        makeEntry({
+          recipient_name: "Test Person",
+          clemency_type: "commutation",
+          offense: "Drug conspiracy",
+          grant_date: "2024-12-01",
+          president_name: "Joseph R. Biden",
+          term_number: 1,
+        }),
+      ],
+      baseOptions,
+    );
+    expect(xml).toContain(
+      "Commutation granted to Test Person by Joseph R. Biden on 2024-12-01. Offense: Drug conspiracy.",
+    );
+  });
+
+  it("uses the configured siteUrl for self-link, alternate-link, and feed id", () => {
+    const xml = buildAtomFeed([makeEntry()], { ...baseOptions, siteUrl: "https://staging.pardonned.com" });
+    expect(xml).toContain("<id>https://staging.pardonned.com/recent.xml</id>");
+    expect(xml).toContain('href="https://staging.pardonned.com/recent.xml"');
+    expect(xml).toContain('href="https://staging.pardonned.com/recent"');
+  });
+});

--- a/src/lib/__tests__/atom-feed.test.ts
+++ b/src/lib/__tests__/atom-feed.test.ts
@@ -205,4 +205,39 @@ describe("buildAtomFeed", () => {
     expect(xml).toContain('href="https://staging.pardonned.com/recent.xml"');
     expect(xml).toContain('href="https://staging.pardonned.com/recent"');
   });
+
+  it("accepts a separate termContextEntries set so display-name suffixes resolve correctly when rendering a scoped subset", () => {
+    // Render only Trump-2 entries, but include both Trump terms in the
+    // context so the helper still recognizes Trump as multi-term.
+    const trump2Only = [
+      makeEntry({
+        slug: "person-a",
+        recipient_name: "Person A",
+        president_name: "Donald J. Trump",
+        term_number: 2,
+      }),
+    ];
+    const fullContext = [
+      ...trump2Only,
+      makeEntry({
+        slug: "person-b",
+        recipient_name: "Person B",
+        president_name: "Donald J. Trump",
+        term_number: 1,
+      }),
+    ];
+
+    const xmlWithoutContext = buildAtomFeed(trump2Only, baseOptions);
+    expect(xmlWithoutContext).toContain("<author><name>Donald J. Trump</name></author>");
+
+    const xmlWithContext = buildAtomFeed(trump2Only, {
+      ...baseOptions,
+      termContextEntries: fullContext,
+    });
+    expect(xmlWithContext).toContain("<author><name>Donald J. Trump (Second Term)</name></author>");
+    // Only Trump-2's entry actually appears in the feed despite the full context
+    expect((xmlWithContext.match(/<entry>/g) ?? []).length).toBe(1);
+    expect(xmlWithContext).toContain("Person A");
+    expect(xmlWithContext).not.toContain("Person B");
+  });
 });

--- a/src/lib/__tests__/category-colors.test.ts
+++ b/src/lib/__tests__/category-colors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  FALLBACK_CATEGORY_COLOR,
+  getCategoryColor,
+  hasExplicitCategoryColor,
+} from "../category-colors";
+
+describe("getCategoryColor", () => {
+  it("returns the expected hex for each DB enum category", () => {
+    expect(getCategoryColor("fraud")).toBe("#8A6B1E");
+    expect(getCategoryColor("drug offense")).toBe("#3A6A4A");
+    expect(getCategoryColor("firearms")).toBe("#C23B22");
+    expect(getCategoryColor("FACE act")).toBe("#B8652A");
+    expect(getCategoryColor("financial crime")).toBe("#2A6A7A");
+    expect(getCategoryColor("violent crime")).toBe("#6A4B7A");
+    expect(getCategoryColor("immigration")).toBe("#7A6A3A");
+    expect(getCategoryColor("other")).toBe("#7A7870");
+  });
+
+  it("returns the fallback for unknown keys (e.g. future AI-derived categories)", () => {
+    expect(getCategoryColor("january 6")).toBe(FALLBACK_CATEGORY_COLOR);
+    expect(getCategoryColor("political corruption")).toBe(FALLBACK_CATEGORY_COLOR);
+    expect(getCategoryColor("cryptocurrency")).toBe(FALLBACK_CATEGORY_COLOR);
+    expect(getCategoryColor("")).toBe(FALLBACK_CATEGORY_COLOR);
+    expect(getCategoryColor("not-a-real-category")).toBe(FALLBACK_CATEGORY_COLOR);
+  });
+});
+
+describe("hasExplicitCategoryColor", () => {
+  it("is true for DB enum values, false for unknowns", () => {
+    expect(hasExplicitCategoryColor("fraud")).toBe(true);
+    expect(hasExplicitCategoryColor("other")).toBe(true);
+    expect(hasExplicitCategoryColor("january 6")).toBe(false);
+    expect(hasExplicitCategoryColor("")).toBe(false);
+  });
+});

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { formatCompactMoney, formatGrantDateLong, formatGrantDateShort } from "../format";
+import {
+  formatCompactMoney,
+  formatCurrencyPrecise,
+  formatGrantDateLong,
+  formatGrantDateShort,
+  formatSentenceCompact,
+  formatSentenceMonths,
+} from "../format";
 
 describe("formatCompactMoney", () => {
   it("formats billions with two-decimal precision and trims trailing zeros", () => {
@@ -42,5 +49,55 @@ describe("formatGrantDateShort", () => {
   it("formats ISO dates with abbreviated month", () => {
     expect(formatGrantDateShort("2017-01-19")).toBe("Jan 19, 2017");
     expect(formatGrantDateShort("2025-12-23")).toBe("Dec 23, 2025");
+  });
+});
+
+describe("formatSentenceMonths", () => {
+  it("renders sub-year sentences with the months unit, singular when needed", () => {
+    expect(formatSentenceMonths(3)).toBe("3 months");
+    expect(formatSentenceMonths(1)).toBe("1 month");
+    expect(formatSentenceMonths(11)).toBe("11 months");
+  });
+
+  it("renders whole years without a remainder", () => {
+    expect(formatSentenceMonths(12)).toBe("1 year");
+    expect(formatSentenceMonths(24)).toBe("2 years");
+    expect(formatSentenceMonths(120)).toBe("10 years");
+  });
+
+  it("renders mixed years + months", () => {
+    expect(formatSentenceMonths(15)).toBe("1 year, 3 months");
+    expect(formatSentenceMonths(30)).toBe("2 years, 6 months");
+    expect(formatSentenceMonths(13)).toBe("1 year, 1 month");
+  });
+
+  it("returns em-dash for null and undefined", () => {
+    expect(formatSentenceMonths(null)).toBe("—");
+    expect(formatSentenceMonths(undefined)).toBe("—");
+  });
+});
+
+describe("formatSentenceCompact", () => {
+  it("uses compact mo/yr forms for tight display", () => {
+    expect(formatSentenceCompact(3)).toBe("3mo");
+    expect(formatSentenceCompact(48)).toBe("4yr");
+    expect(formatSentenceCompact(126)).toBe("10yr 6mo");
+  });
+
+  it("returns em-dash for null", () => {
+    expect(formatSentenceCompact(null)).toBe("—");
+  });
+});
+
+describe("formatCurrencyPrecise", () => {
+  it("formats integer-USD amounts with thousands separators", () => {
+    expect(formatCurrencyPrecise(680_000_000)).toBe("$680,000,000");
+    expect(formatCurrencyPrecise(1_000)).toBe("$1,000");
+  });
+
+  it("returns em-dash for null but preserves $0 for zero (absence vs. zero is meaningful at row level)", () => {
+    expect(formatCurrencyPrecise(null)).toBe("—");
+    expect(formatCurrencyPrecise(undefined)).toBe("—");
+    expect(formatCurrencyPrecise(0)).toBe("$0");
   });
 });

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactMoney, formatGrantDateLong, formatGrantDateShort } from "../format";
+
+describe("formatCompactMoney", () => {
+  it("formats billions with two-decimal precision and trims trailing zeros", () => {
+    expect(formatCompactMoney(1_470_000_000)).toBe("$1.47B");
+    expect(formatCompactMoney(2_000_000_000)).toBe("$2B");
+    expect(formatCompactMoney(1_350_000_000)).toBe("$1.35B");
+  });
+
+  it("formats millions with one-decimal precision and trims trailing .0", () => {
+    expect(formatCompactMoney(92_400_000)).toBe("$92.4M");
+    expect(formatCompactMoney(4_400_000)).toBe("$4.4M");
+    expect(formatCompactMoney(50_000_000)).toBe("$50M");
+  });
+
+  it("formats thousands rounded to integer K", () => {
+    expect(formatCompactMoney(508_000)).toBe("$508K");
+    expect(formatCompactMoney(20_000)).toBe("$20K");
+  });
+
+  it("falls through to locale-string for sub-thousand values", () => {
+    expect(formatCompactMoney(742)).toBe("$742");
+    expect(formatCompactMoney(1)).toBe("$1");
+  });
+
+  it("renders $0 for zero, null, and undefined", () => {
+    expect(formatCompactMoney(0)).toBe("$0");
+    expect(formatCompactMoney(null)).toBe("$0");
+    expect(formatCompactMoney(undefined)).toBe("$0");
+  });
+});
+
+describe("formatGrantDateLong", () => {
+  it("formats ISO dates with full month and four-digit year", () => {
+    expect(formatGrantDateLong("2017-01-19")).toBe("January 19, 2017");
+    expect(formatGrantDateLong("2025-12-23")).toBe("December 23, 2025");
+  });
+});
+
+describe("formatGrantDateShort", () => {
+  it("formats ISO dates with abbreviated month", () => {
+    expect(formatGrantDateShort("2017-01-19")).toBe("Jan 19, 2017");
+    expect(formatGrantDateShort("2025-12-23")).toBe("Dec 23, 2025");
+  });
+});

--- a/src/lib/__tests__/pardon-stats.test.ts
+++ b/src/lib/__tests__/pardon-stats.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  HEADLINE_ACTION_THRESHOLD,
+  findHeadlineAction,
+} from "../pardon-stats";
+import type { PardonDetail } from "../../loaders/pardon-details";
+
+function makeEntry(overrides: Partial<PardonDetail> = {}) {
+  return {
+    id: overrides.id ?? "1",
+    data: {
+      id: "1",
+      slug: "x",
+      administration_slug: "trump-2",
+      grant_date: "2025-03-28",
+      clemency_type: "pardon" as const,
+      offense: "Test",
+      offense_category: "fraud",
+      district: null,
+      warrant_url: null,
+      source_url: null,
+      recipient_name: "Test",
+      sentence_in_months: null,
+      fine: null,
+      restitution: null,
+      original_sentence: null,
+      president_name: "Test President",
+      term_number: 1,
+      term_start_date: "2025-01-20",
+      term_end_date: null,
+      ...overrides,
+    } as PardonDetail,
+  };
+}
+
+describe("findHeadlineAction", () => {
+  it("returns null when no single (date, category) cluster reaches the threshold", () => {
+    const entries = Array.from({ length: 30 }, (_, i) =>
+      makeEntry({
+        slug: `r-${i}`,
+        grant_date: "2024-01-01",
+        offense_category: "fraud",
+        clemency_type: "pardon",
+      }),
+    );
+    expect(findHeadlineAction(entries)).toBeNull();
+  });
+
+  it("surfaces a cluster of exactly the threshold size", () => {
+    const entries = Array.from({ length: HEADLINE_ACTION_THRESHOLD }, (_, i) =>
+      makeEntry({
+        slug: `r-${i}`,
+        grant_date: "2017-01-19",
+        offense_category: "drug offense",
+        clemency_type: "commutation",
+      }),
+    );
+    const result = findHeadlineAction(entries);
+    expect(result).not.toBeNull();
+    expect(result?.count).toBe(HEADLINE_ACTION_THRESHOLD);
+    expect(result?.date).toBe("2017-01-19");
+    expect(result?.category).toBe("drug offense");
+    expect(result?.clemencyType).toBe("commutation");
+  });
+
+  it("picks the largest cluster when multiple exceed the threshold", () => {
+    const entries = [
+      ...Array.from({ length: 60 }, (_, i) =>
+        makeEntry({
+          slug: `a-${i}`,
+          grant_date: "2024-12-01",
+          offense_category: "fraud",
+          clemency_type: "pardon",
+        }),
+      ),
+      ...Array.from({ length: 100 }, (_, i) =>
+        makeEntry({
+          slug: `b-${i}`,
+          grant_date: "2017-01-19",
+          offense_category: "drug offense",
+          clemency_type: "commutation",
+        }),
+      ),
+    ];
+    const result = findHeadlineAction(entries);
+    expect(result?.count).toBe(100);
+    expect(result?.category).toBe("drug offense");
+    expect(result?.date).toBe("2017-01-19");
+  });
+
+  it("clusters are keyed on (date, category) — same date, different categories don't merge", () => {
+    const entries = [
+      ...Array.from({ length: 40 }, (_, i) =>
+        makeEntry({
+          slug: `a-${i}`,
+          grant_date: "2024-12-01",
+          offense_category: "fraud",
+        }),
+      ),
+      ...Array.from({ length: 40 }, (_, i) =>
+        makeEntry({
+          slug: `b-${i}`,
+          grant_date: "2024-12-01",
+          offense_category: "drug offense",
+        }),
+      ),
+    ];
+    // Neither cluster individually hits the threshold; combined date count is 80
+    // but findHeadlineAction does not merge across categories.
+    expect(findHeadlineAction(entries)).toBeNull();
+  });
+
+  it("derives clemencyType from the majority within the cluster", () => {
+    const entries = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeEntry({
+          slug: `p-${i}`,
+          grant_date: "2024-12-01",
+          offense_category: "fraud",
+          clemency_type: "pardon",
+        }),
+      ),
+      ...Array.from({ length: 60 }, (_, i) =>
+        makeEntry({
+          slug: `c-${i}`,
+          grant_date: "2024-12-01",
+          offense_category: "fraud",
+          clemency_type: "commutation",
+        }),
+      ),
+    ];
+    const result = findHeadlineAction(entries);
+    expect(result?.count).toBe(65);
+    expect(result?.clemencyType).toBe("commutation");
+  });
+
+  it("handles empty input", () => {
+    expect(findHeadlineAction([])).toBeNull();
+  });
+
+  it("works with future AI-derived categories (e.g. 'january 6')", () => {
+    // Validates the data-driven design: when J6 records land later, this
+    // function will surface them automatically with no code change.
+    const entries = Array.from({ length: 1500 }, (_, i) =>
+      makeEntry({
+        slug: `j6-${i}`,
+        grant_date: "2025-01-20",
+        offense_category: "january 6",
+        clemency_type: "pardon",
+      }),
+    );
+    const result = findHeadlineAction(entries);
+    expect(result?.count).toBe(1500);
+    expect(result?.category).toBe("january 6");
+    expect(result?.date).toBe("2025-01-20");
+  });
+});

--- a/src/lib/__tests__/president-names.test.ts
+++ b/src/lib/__tests__/president-names.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { formatAdministrationDisplayName, getAdministrationIndex } from "../president-names";
+import {
+  formatAdministrationDisplayName,
+  getAdministrationIndex,
+  getCurrentAdministration,
+} from "../president-names";
 
 describe("formatAdministrationDisplayName", () => {
   it("returns just the name for a single-term president", () => {
@@ -73,58 +77,58 @@ describe("formatAdministrationDisplayName", () => {
   });
 });
 
-describe("getAdministrationIndex", () => {
-  const fixture = [
-    {
-      data: {
-        administration_slug: "biden-1",
-        president_name: "Joe Biden",
-        term_number: 1,
-        term_start_date: "2021-01-20",
-      },
+const fixture = [
+  {
+    data: {
+      administration_slug: "biden-1",
+      president_name: "Joe Biden",
+      term_number: 1,
+      term_start_date: "2021-01-20",
     },
-    {
-      data: {
-        administration_slug: "biden-1",
-        president_name: "Joe Biden",
-        term_number: 1,
-        term_start_date: "2021-01-20",
-      },
+  },
+  {
+    data: {
+      administration_slug: "biden-1",
+      president_name: "Joe Biden",
+      term_number: 1,
+      term_start_date: "2021-01-20",
     },
-    {
-      data: {
-        administration_slug: "trump-1",
-        president_name: "Donald Trump",
-        term_number: 1,
-        term_start_date: "2017-01-20",
-      },
+  },
+  {
+    data: {
+      administration_slug: "trump-1",
+      president_name: "Donald Trump",
+      term_number: 1,
+      term_start_date: "2017-01-20",
     },
-    {
-      data: {
-        administration_slug: "trump-2",
-        president_name: "Donald Trump",
-        term_number: 2,
-        term_start_date: "2025-01-20",
-      },
+  },
+  {
+    data: {
+      administration_slug: "trump-2",
+      president_name: "Donald Trump",
+      term_number: 2,
+      term_start_date: "2025-01-20",
     },
-    {
-      data: {
-        administration_slug: "trump-2",
-        president_name: "Donald Trump",
-        term_number: 2,
-        term_start_date: "2025-01-20",
-      },
+  },
+  {
+    data: {
+      administration_slug: "trump-2",
+      president_name: "Donald Trump",
+      term_number: 2,
+      term_start_date: "2025-01-20",
     },
-    {
-      data: {
-        administration_slug: "trump-2",
-        president_name: "Donald Trump",
-        term_number: 2,
-        term_start_date: "2025-01-20",
-      },
+  },
+  {
+    data: {
+      administration_slug: "trump-2",
+      president_name: "Donald Trump",
+      term_number: 2,
+      term_start_date: "2025-01-20",
     },
-  ];
+  },
+];
 
+describe("getAdministrationIndex", () => {
   it("builds one entry per unique administration slug", () => {
     const index = getAdministrationIndex(fixture);
     expect(index.size).toBe(3);
@@ -169,5 +173,70 @@ describe("getAdministrationIndex", () => {
   it("returns an empty map for an empty collection", () => {
     const index = getAdministrationIndex([]);
     expect(index.size).toBe(0);
+  });
+});
+
+describe("getCurrentAdministration", () => {
+  it("returns the admin with the most recent term_start_date", () => {
+    const result = getCurrentAdministration(fixture);
+    expect(result?.slug).toBe("trump-2");
+  });
+
+  it("returns null for empty input", () => {
+    expect(getCurrentAdministration([])).toBeNull();
+  });
+
+  it("breaks ties on identical start dates by higher term_number first", () => {
+    const tied = [
+      {
+        data: {
+          administration_slug: "a-1",
+          president_name: "President A",
+          term_number: 1,
+          term_start_date: "2025-01-20",
+        },
+      },
+      {
+        data: {
+          administration_slug: "b-2",
+          president_name: "President B",
+          term_number: 2,
+          term_start_date: "2025-01-20",
+        },
+      },
+    ];
+    expect(getCurrentAdministration(tied)?.slug).toBe("b-2");
+  });
+
+  it("works with a single-admin dataset", () => {
+    const sole = [
+      {
+        data: {
+          administration_slug: "trump-2",
+          president_name: "Donald Trump",
+          term_number: 2,
+          term_start_date: "2025-01-20",
+        },
+      },
+    ];
+    expect(getCurrentAdministration(sole)?.slug).toBe("trump-2");
+  });
+
+  it("auto-rotates when a future admin's data lands (no code change)", () => {
+    // Validates the data-driven design: as soon as the next admin's
+    // grants appear in the dataset with a later term_start_date, the
+    // helper returns them without modification.
+    const next = [
+      ...fixture,
+      {
+        data: {
+          administration_slug: "vance-1",
+          president_name: "JD Vance",
+          term_number: 1,
+          term_start_date: "2029-01-20",
+        },
+      },
+    ];
+    expect(getCurrentAdministration(next)?.slug).toBe("vance-1");
   });
 });

--- a/src/lib/atom-feed.ts
+++ b/src/lib/atom-feed.ts
@@ -1,0 +1,112 @@
+import type { PardonDetail } from "../loaders/pardon-details";
+import { formatAdministrationDisplayName } from "./president-names";
+
+/**
+ * Atom 1.0 feed generator for the recent-grants feed at /recent.xml.
+ *
+ * Pure function: takes pre-sorted entries plus site metadata, returns
+ * an Atom 1.0 XML document as a string. Kept separate from the APIRoute
+ * so the rendering logic is unit-testable without mocking
+ * `getCollection`.
+ */
+
+export interface AtomEntry {
+  id: string;
+  data: PardonDetail;
+}
+
+export interface AtomFeedOptions {
+  siteUrl: string;
+  feedTitle: string;
+  feedSubtitle: string;
+  authorName: string;
+  /** Maximum number of entries to include. Default 50. */
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function toRfc3339(isoDate: string): string {
+  // grant_date is stored as YYYY-MM-DD; Atom requires RFC 3339 timestamps.
+  // Use noon UTC to avoid timezone drift around date boundaries.
+  return `${isoDate}T12:00:00Z`;
+}
+
+function buildTermsIndex(entries: AtomEntry[]): Map<string, Set<number>> {
+  const index = new Map<string, Set<number>>();
+  for (const entry of entries) {
+    let terms = index.get(entry.data.president_name);
+    if (!terms) {
+      terms = new Set();
+      index.set(entry.data.president_name, terms);
+    }
+    terms.add(entry.data.term_number);
+  }
+  return index;
+}
+
+/**
+ * Build an Atom 1.0 feed from pardon detail entries.
+ *
+ * `entries` should be the full set (used to compute administration display
+ * names with correct multi-term suffixes). The function sorts internally
+ * by `grant_date` desc and slices to `limit`.
+ */
+export function buildAtomFeed(entries: AtomEntry[], options: AtomFeedOptions): string {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const sorted = entries
+    .slice()
+    .sort((a, b) => b.data.grant_date.localeCompare(a.data.grant_date))
+    .slice(0, limit);
+
+  const feedUpdated =
+    sorted.length > 0 ? toRfc3339(sorted[0].data.grant_date) : new Date().toISOString();
+
+  const termsPerPresident = buildTermsIndex(entries);
+
+  const entriesXml = sorted
+    .map((entry) => {
+      const d = entry.data;
+      const detailUrl = `${options.siteUrl}/pardon/details/${d.slug}`;
+      const adminDisplay = formatAdministrationDisplayName({
+        presidentName: d.president_name,
+        termNumber: d.term_number,
+        isOnlyTerm: termsPerPresident.get(d.president_name)!.size === 1,
+      });
+      const clemencyLabel = d.clemency_type === "pardon" ? "Pardon" : "Commutation";
+      const summary = `${clemencyLabel} granted to ${d.recipient_name} by ${adminDisplay} on ${d.grant_date}. Offense: ${d.offense}.`;
+
+      return `  <entry>
+    <id>tag:pardonned.com,${d.grant_date}:pardon-${escapeXml(d.slug)}</id>
+    <title>${escapeXml(d.recipient_name)} — ${clemencyLabel}</title>
+    <link rel="alternate" type="text/html" href="${escapeXml(detailUrl)}"/>
+    <published>${toRfc3339(d.grant_date)}</published>
+    <updated>${toRfc3339(d.grant_date)}</updated>
+    <author><name>${escapeXml(adminDisplay)}</name></author>
+    <summary type="text">${escapeXml(summary)}</summary>
+  </entry>`;
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>${options.siteUrl}/recent.xml</id>
+  <title>${escapeXml(options.feedTitle)}</title>
+  <subtitle>${escapeXml(options.feedSubtitle)}</subtitle>
+  <link rel="self" type="application/atom+xml" href="${options.siteUrl}/recent.xml"/>
+  <link rel="alternate" type="text/html" href="${options.siteUrl}/recent"/>
+  <updated>${feedUpdated}</updated>
+  <author><name>${escapeXml(options.authorName)}</name></author>
+${entriesXml}
+</feed>
+`;
+}

--- a/src/lib/atom-feed.ts
+++ b/src/lib/atom-feed.ts
@@ -22,6 +22,13 @@ export interface AtomFeedOptions {
   authorName: string;
   /** Maximum number of entries to include. Default 50. */
   limit?: number;
+  /**
+   * Optional fuller set of entries used solely to derive per-president
+   * term counts (so multi-term display-name suffixes resolve correctly
+   * when `entries` is a scoped subset, e.g. current-administration only).
+   * Defaults to `entries` itself.
+   */
+  termContextEntries?: AtomEntry[];
 }
 
 const DEFAULT_LIMIT = 50;
@@ -71,7 +78,7 @@ export function buildAtomFeed(entries: AtomEntry[], options: AtomFeedOptions): s
   const feedUpdated =
     sorted.length > 0 ? toRfc3339(sorted[0].data.grant_date) : new Date().toISOString();
 
-  const termsPerPresident = buildTermsIndex(entries);
+  const termsPerPresident = buildTermsIndex(options.termContextEntries ?? entries);
 
   const entriesXml = sorted
     .map((entry) => {

--- a/src/lib/category-colors.ts
+++ b/src/lib/category-colors.ts
@@ -1,0 +1,36 @@
+/**
+ * Color resolution for offense categories.
+ *
+ * Single source of truth for category → hex color mapping. Replaces the
+ * triplicated `categoryColors` map that previously lived inline in
+ * `src/pages/search.astro`, `src/pages/president/[slug].astro`, and
+ * `src/components/CategoryBadge.astro`.
+ *
+ * The DB enum currently has 8 values. A separate AI-reclassification
+ * effort will surface additional categories (`january 6`, `political
+ * corruption`, `cryptocurrency`). Unknown keys — including those future
+ * ones until they're explicitly assigned a color here — fall back to a
+ * neutral grey rather than throwing, so the UI degrades gracefully when
+ * new categories appear in the data ahead of a UI deploy.
+ */
+
+export const FALLBACK_CATEGORY_COLOR = "#7A7870";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  fraud: "#8A6B1E",
+  "drug offense": "#3A6A4A",
+  firearms: "#C23B22",
+  "FACE act": "#B8652A",
+  "financial crime": "#2A6A7A",
+  "violent crime": "#6A4B7A",
+  immigration: "#7A6A3A",
+  other: "#7A7870",
+};
+
+export function getCategoryColor(key: string): string {
+  return CATEGORY_COLORS[key] ?? FALLBACK_CATEGORY_COLOR;
+}
+
+export function hasExplicitCategoryColor(key: string): boolean {
+  return key in CATEGORY_COLORS;
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,46 @@
+/**
+ * Compact money formatter for display-scale figures: $1.47B, $92.4M, $4.4K, $508.
+ *
+ * Used wherever a money value needs to fit in a tight typographic frame —
+ * the number wall, comparison strip, restitution leaderboard. For the
+ * detail page's row-level metadata grid we keep full-precision currency
+ * via `Intl.NumberFormat` instead.
+ */
+export function formatCompactMoney(value: number | null | undefined): string {
+  if (value == null || value === 0) return "$0";
+  if (value >= 1_000_000_000) {
+    return `$${(value / 1_000_000_000).toFixed(2).replace(/\.?0+$/, "")}B`;
+  }
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  }
+  if (value >= 1_000) {
+    return `$${Math.round(value / 1_000)}K`;
+  }
+  return `$${value.toLocaleString()}`;
+}
+
+/**
+ * Format an ISO date (YYYY-MM-DD) as e.g. "January 19, 2017" using local
+ * date construction (avoids the off-by-one timezone trap of `new Date("YYYY-MM-DD")`).
+ */
+export function formatGrantDateLong(isoDate: string): string {
+  const [y, m, d] = isoDate.split("-");
+  return new Date(Number(y), Number(m) - 1, Number(d)).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+/**
+ * Format an ISO date as e.g. "Jan 19, 2017".
+ */
+export function formatGrantDateShort(isoDate: string): string {
+  const [y, m, d] = isoDate.split("-");
+  return new Date(Number(y), Number(m) - 1, Number(d)).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -44,3 +44,48 @@ export function formatGrantDateShort(isoDate: string): string {
     day: "numeric",
   });
 }
+
+/**
+ * Format a `sentence_in_months` value as a human-readable phrase.
+ * Returns an em-dash for null/undefined.
+ *
+ *   3   → "3 months"
+ *   12  → "1 year"
+ *   30  → "2 years, 6 months"
+ *   240 → "20 years"
+ */
+export function formatSentenceMonths(months: number | null | undefined): string {
+  if (months == null) return "—";
+  if (months < 12) return `${months} ${months === 1 ? "month" : "months"}`;
+  const years = Math.floor(months / 12);
+  const remainder = months % 12;
+  const yearsLabel = `${years} ${years === 1 ? "year" : "years"}`;
+  if (remainder === 0) return yearsLabel;
+  return `${yearsLabel}, ${remainder} ${remainder === 1 ? "month" : "months"}`;
+}
+
+/**
+ * Compact sentence formatter for tight display (e.g. detail-page money
+ * strip). Returns a short form like "48mo", "4yr", "10yr 6mo".
+ */
+export function formatSentenceCompact(months: number | null | undefined): string {
+  if (months == null) return "—";
+  if (months < 12) return `${months}mo`;
+  const years = Math.floor(months / 12);
+  const remainder = months % 12;
+  if (remainder === 0) return `${years}yr`;
+  return `${years}yr ${remainder}mo`;
+}
+
+/**
+ * Precise USD currency. Used on the row-level metadata grid where
+ * absence is meaningful — returns "—" for null and "$0" for zero.
+ */
+export function formatCurrencyPrecise(amount: number | null | undefined): string {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}

--- a/src/lib/pardon-stats.ts
+++ b/src/lib/pardon-stats.ts
@@ -141,3 +141,69 @@ export function filterByAdministration(
 ): CollectionEntry[] {
   return entries.filter((e) => e.data.administration_slug === slug);
 }
+
+/** Headline-action surfacing — used by the bold homepage's by-administration strip. */
+export interface HeadlineAction {
+  count: number;
+  date: string;
+  category: string;
+  clemencyType: "pardon" | "commutation";
+}
+
+/**
+ * Threshold above which a single-day single-category cluster is loud
+ * enough to be worth surfacing as an annotation. Tunable.
+ */
+export const HEADLINE_ACTION_THRESHOLD = 50;
+
+/**
+ * Find the largest single-day single-category cluster of grants in
+ * `entries`. Returns null if no cluster reaches HEADLINE_ACTION_THRESHOLD.
+ *
+ * The bold homepage's by-administration strip uses this to render
+ * annotations like "1,617 drug commutations on Jan 19, 2017." under
+ * each row. Data-driven: as new categories appear (e.g. `january 6`
+ * after the AI reclassification effort lands), this surfaces them
+ * automatically without code changes.
+ */
+export function findHeadlineAction(entries: CollectionEntry[]): HeadlineAction | null {
+  interface Bucket {
+    count: number;
+    date: string;
+    category: string;
+    pardons: number;
+    commutations: number;
+  }
+  const buckets = new Map<string, Bucket>();
+  for (const entry of entries) {
+    const d = entry.data;
+    const key = `${d.grant_date}|${d.offense_category}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        count: 0,
+        date: d.grant_date,
+        category: d.offense_category,
+        pardons: 0,
+        commutations: 0,
+      };
+      buckets.set(key, bucket);
+    }
+    bucket.count++;
+    if (d.clemency_type === "pardon") bucket.pardons++;
+    else bucket.commutations++;
+  }
+
+  let max: Bucket | null = null;
+  for (const bucket of buckets.values()) {
+    if (!max || bucket.count > max.count) max = bucket;
+  }
+  if (!max || max.count < HEADLINE_ACTION_THRESHOLD) return null;
+
+  return {
+    count: max.count,
+    date: max.date,
+    category: max.category,
+    clemencyType: max.commutations > max.pardons ? "commutation" : "pardon",
+  };
+}

--- a/src/lib/president-names.ts
+++ b/src/lib/president-names.ts
@@ -114,3 +114,31 @@ export function getAdministrationIndex(
 
   return index;
 }
+
+/**
+ * Identify the current administration — the one with the most recent
+ * `term_start_date` in the dataset. Returns null for an empty dataset.
+ *
+ * Used by `/recent` and its companion Atom feed to scope the feed to
+ * the incumbent administration only. Data-driven: when the next
+ * administration's grants start landing, the helper returns that admin
+ * automatically without code changes.
+ *
+ * Ties on term_start_date break toward the higher term_number, then by
+ * slug for deterministic ordering.
+ */
+export function getCurrentAdministration(
+  entries: AdministrationIndexInput[],
+): AdministrationIndexEntry | null {
+  const index = getAdministrationIndex(entries);
+  if (index.size === 0) return null;
+  const admins = Array.from(index.values());
+  admins.sort((a, b) => {
+    const dc = b.termStartDate.localeCompare(a.termStartDate);
+    if (dc !== 0) return dc;
+    const tc = b.termNumber - a.termNumber;
+    if (tc !== 0) return tc;
+    return a.slug.localeCompare(b.slug);
+  });
+  return admins[0];
+}

--- a/src/pages/all-presidents.astro
+++ b/src/pages/all-presidents.astro
@@ -1,0 +1,828 @@
+---
+import Layout from "../layouts/Layout.astro";
+import "../styles/global.css";
+
+import { getCollection } from "astro:content";
+import { computeStats, filterByAdministration } from "../lib/pardon-stats";
+import { getAdministrationIndex } from "../lib/president-names";
+import { getCategoryColor } from "../lib/category-colors";
+import { formatCompactMoney } from "../lib/format";
+
+const currentPath = Astro.url.pathname;
+const MODERN_ERA_START = "1993-01-01";
+
+const allGrants = await getCollection("pardonDetails");
+const modernEraGrants = allGrants.filter(
+    (e) => e.data.term_start_date >= MODERN_ERA_START,
+);
+
+const adminIndex = getAdministrationIndex(modernEraGrants);
+const modernAdmins = Array.from(adminIndex.values());
+
+// Build per-admin row data with stats
+interface AdminRow {
+    slug: string;
+    displayName: string;
+    presidentName: string;
+    termNumber: number;
+    termStartDate: string;
+    termEndDate: string | null;
+    yearRange: string;
+    grants: number;
+    pardons: number;
+    commutations: number;
+    restitution: number;
+    fines: number;
+    byCategory: Record<string, number>;
+}
+
+const adminRows: AdminRow[] = modernAdmins.map((admin) => {
+    const entries = filterByAdministration(modernEraGrants, admin.slug);
+    const stats = computeStats(entries);
+    const termEndDate = entries[0]?.data.term_end_date ?? null;
+    const startYear = admin.termStartDate.slice(0, 4);
+    const endYear = termEndDate ? termEndDate.slice(0, 4) : "";
+    return {
+        slug: admin.slug,
+        displayName: admin.displayName,
+        presidentName: admin.presidentName,
+        termNumber: admin.termNumber,
+        termStartDate: admin.termStartDate,
+        termEndDate,
+        yearRange: endYear ? `${startYear}–${endYear}` : `${startYear}–`,
+        grants: stats.totalGrants,
+        pardons: stats.totalPardons,
+        commutations: stats.totalCommutations,
+        restitution: stats.totalRestitutionAbandoned,
+        fines: stats.totalFinesAbandoned,
+        byCategory: stats.byCategory,
+    };
+});
+
+// Default sort: total grants desc (server-rendered; JS only enhances re-sort)
+adminRows.sort((a, b) => b.grants - a.grants);
+
+// Page-level totals
+const totalStats = computeStats(modernEraGrants);
+const presidentNames = new Set(modernAdmins.map((a) => a.presidentName));
+const presidentCount = presidentNames.size;
+const oldestStartYear = modernAdmins
+    .map((a) => a.termStartDate.slice(0, 4))
+    .sort()[0];
+const newestEndYear = adminRows
+    .map((r) => (r.termEndDate ? r.termEndDate.slice(0, 4) : null))
+    .filter(Boolean)
+    .sort()
+    .reverse()[0];
+const yearsCovered = newestEndYear
+    ? Number(newestEndYear) - Number(oldestStartYear)
+    : new Date().getFullYear() - Number(oldestStartYear);
+const avgPerTerm =
+    modernAdmins.length > 0
+        ? Math.round(totalStats.totalGrants / modernAdmins.length)
+        : 0;
+
+// Composition: collect every category that appears in the modern era,
+// ordered by overall count desc — used for the stacked-bar legend.
+const allCategoriesSorted = Object.entries(totalStats.byCategory)
+    .sort(([, a], [, b]) => b - a)
+    .map(([key]) => key);
+
+// Headline year range for the eyebrow
+const eyebrowYears = newestEndYear
+    ? `${oldestStartYear} → ${newestEndYear}`
+    : `${oldestStartYear} → present`;
+---
+
+<Layout
+    title="All presidents"
+    description="Side-by-side clemency comparison of every U.S. presidential administration since 1993. Sortable by grants, restitution, and term."
+    ogImage="/og/all-presidents.png"
+    currentPath={currentPath}
+>
+    <main class="ap-page">
+        <div class="ap-crumb">
+            <a href="/">Home</a>
+            <span class="ap-crumb-sep">/</span>
+            <span class="ap-crumb-here">All presidents</span>
+        </div>
+
+        <header class="ap-mast">
+            <div class="ap-mast-kicker">
+                Cross-administration comparison · {eyebrowYears}
+            </div>
+            <h1 class="ap-mast-headline">
+                <span class="ap-quiet">{presidentCount} presidents.</span><br />
+                {modernAdmins.length} terms.<br />
+                <span class="ap-red">
+                    {formatCompactMoney(totalStats.totalRestitutionAbandoned)}
+                </span>
+                in restitution.
+            </h1>
+            <p class="ap-mast-deck">
+                A side-by-side look at every administration's clemency record
+                since {oldestStartYear} — by volume, by money forgiven, and by
+                composition. Drawn from the same DOJ source for every term.
+                Click any column header to re-sort.
+            </p>
+        </header>
+
+        <!-- Totals strip -->
+        <section class="ap-totals">
+            <div class="ap-tcell">
+                <div class="ap-tlbl">Grants tracked</div>
+                <div class="ap-tbig">
+                    {totalStats.totalGrants.toLocaleString()}
+                </div>
+                <div class="ap-tsub">
+                    Pardons + commutations across all administrations.
+                </div>
+            </div>
+            <div class="ap-tcell">
+                <div class="ap-tlbl">Restitution forgiven</div>
+                <div class="ap-tbig ap-tbig-accent">
+                    {formatCompactMoney(totalStats.totalRestitutionAbandoned)}
+                </div>
+                <div class="ap-tsub">
+                    Money owed to victims that recipients no longer have to pay back.
+                </div>
+            </div>
+            <div class="ap-tcell">
+                <div class="ap-tlbl">Years covered</div>
+                <div class="ap-tbig">{yearsCovered}</div>
+                <div class="ap-tsub">
+                    January {oldestStartYear} to present.
+                </div>
+            </div>
+            <div class="ap-tcell">
+                <div class="ap-tlbl">Avg per term</div>
+                <div class="ap-tbig">{avgPerTerm.toLocaleString()}</div>
+                <div class="ap-tsub">
+                    Wide variance — Obama's second term skews the mean.
+                </div>
+            </div>
+        </section>
+
+        <!-- Sortable comparison table -->
+        <section class="ap-section">
+            <h2 class="ap-section-title">Ranked by total grants.</h2>
+            <p class="ap-section-deck">
+                Each term shown separately. Default sort is by total grants;
+                click any column header to re-sort. Page works without JavaScript
+                for the default view.
+            </p>
+
+            <table class="ap-table" id="ap-table">
+                <thead>
+                    <tr>
+                        <th class="ap-num">
+                            <button type="button" class="ap-sort-btn" data-sort-key="rank" data-default-dir="asc" aria-sort="none">
+                                #
+                            </button>
+                        </th>
+                        <th>
+                            <button type="button" class="ap-sort-btn" data-sort-key="presidentName" data-default-dir="asc" aria-sort="none">
+                                President · Term
+                            </button>
+                        </th>
+                        <th class="ap-num">
+                            <button type="button" class="ap-sort-btn" data-sort-key="grants" data-default-dir="desc" aria-sort="descending">
+                                Grants <span class="ap-sort-mark">▼</span>
+                            </button>
+                        </th>
+                        <th class="ap-num">
+                            <button type="button" class="ap-sort-btn" data-sort-key="pardons" data-default-dir="desc" aria-sort="none">
+                                Pardons
+                            </button>
+                        </th>
+                        <th class="ap-num">
+                            <button type="button" class="ap-sort-btn" data-sort-key="commutations" data-default-dir="desc" aria-sort="none">
+                                Commutations
+                            </button>
+                        </th>
+                        <th class="ap-num">
+                            <button type="button" class="ap-sort-btn" data-sort-key="restitution" data-default-dir="desc" aria-sort="none">
+                                Restitution
+                            </button>
+                        </th>
+                        <th class="ap-num">
+                            <button type="button" class="ap-sort-btn" data-sort-key="fines" data-default-dir="desc" aria-sort="none">
+                                Fines
+                            </button>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="ap-tbody">
+                    {adminRows.map((row, i) => (
+                        <tr
+                            class="ap-row"
+                            data-slug={row.slug}
+                            data-rank={i + 1}
+                            data-grants={row.grants}
+                            data-pardons={row.pardons}
+                            data-commutations={row.commutations}
+                            data-restitution={row.restitution}
+                            data-fines={row.fines}
+                            data-president-name={row.presidentName}
+                            data-term-start={row.termStartDate}
+                        >
+                            <td class="ap-num ap-rank-cell">{i + 1}</td>
+                            <td>
+                                <div class="ap-pres-name">
+                                    {row.presidentName}
+                                </div>
+                                <div class="ap-pres-term">
+                                    {row.displayName.includes("Term")
+                                        ? row.displayName.replace(/^[^(]+\(/, "").replace(")", "")
+                                        : "Sole term"}
+                                    {" · "}
+                                    {row.yearRange}
+                                </div>
+                            </td>
+                            <td class="ap-num ap-cell-grants">
+                                {row.grants.toLocaleString()}
+                            </td>
+                            <td class="ap-num">
+                                {row.pardons.toLocaleString()}
+                            </td>
+                            <td class="ap-num">
+                                {row.commutations.toLocaleString()}
+                            </td>
+                            <td class:list={["ap-num", "ap-money", row.restitution === 0 && "ap-money-zero"]}>
+                                {row.restitution > 0
+                                    ? formatCompactMoney(row.restitution)
+                                    : "—"}
+                            </td>
+                            <td class:list={["ap-num", "ap-money", row.fines === 0 && "ap-money-zero"]}>
+                                {row.fines > 0
+                                    ? formatCompactMoney(row.fines)
+                                    : "—"}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </section>
+
+        <!-- Composition by category — stacked horizontal bars -->
+        <section class="ap-section">
+            <h2 class="ap-section-title">Composition by category.</h2>
+            <p class="ap-section-deck">
+                Each row shows the offense-category mix of one term's grants,
+                scaled to fill the row. The legend below maps colors to
+                categories.
+            </p>
+
+            <div class="ap-stack">
+                <div class="ap-stack-row ap-stack-head">
+                    <div>President · Term</div>
+                    <div>Composition (proportional)</div>
+                    <div class="ap-num">Total</div>
+                </div>
+                {adminRows.map((row) => {
+                    const segments = Object.entries(row.byCategory)
+                        .sort(([a], [b]) => {
+                            const ai = allCategoriesSorted.indexOf(a);
+                            const bi = allCategoriesSorted.indexOf(b);
+                            return ai - bi;
+                        })
+                        .map(([key, count]) => ({
+                            key,
+                            count,
+                            color: getCategoryColor(key),
+                            pct: (count / row.grants) * 100,
+                        }));
+                    return (
+                        <div class="ap-stack-row">
+                            <div class="ap-stack-pres">
+                                <div class="ap-stack-pres-name">
+                                    {row.presidentName}
+                                </div>
+                                <div class="ap-stack-pres-term">
+                                    {row.displayName.includes("Term")
+                                        ? row.displayName.replace(/^[^(]+\(/, "").replace(")", "")
+                                        : "Sole term"}
+                                    {" · "}
+                                    {row.yearRange}
+                                </div>
+                            </div>
+                            <div class="ap-stack-bar" role="img" aria-label={`Composition of ${row.displayName}'s grants`}>
+                                {segments.map((seg) => (
+                                    <span
+                                        class="ap-stack-seg"
+                                        style={`width:${seg.pct}%; background:${seg.color};`}
+                                        title={`${seg.key.replace(/\b\w/g, (c) => c.toUpperCase())}: ${seg.count.toLocaleString()} (${seg.pct.toFixed(1)}%)`}
+                                    ></span>
+                                ))}
+                            </div>
+                            <div class="ap-num ap-stack-total">
+                                {row.grants.toLocaleString()}
+                            </div>
+                        </div>
+                    );
+                })}
+
+                <div class="ap-stack-legend">
+                    {allCategoriesSorted.map((cat) => (
+                        <div class="ap-stack-legend-item">
+                            <span class="ap-stack-legend-sw" style={`background:${getCategoryColor(cat)};`}></span>
+                            <span class="ap-stack-legend-label">
+                                {cat.replace(/\b\w/g, (c) => c.toUpperCase())}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    </main>
+</Layout>
+
+<script is:inline>
+    document.addEventListener("DOMContentLoaded", () => {
+        const tbody = document.getElementById("ap-tbody");
+        if (!tbody) return;
+
+        // Snapshot the rows once. Sorting reorders this array and re-appends
+        // to keep it deterministic across multiple sorts.
+        const rows = Array.from(tbody.querySelectorAll("tr.ap-row"));
+        const buttons = Array.from(document.querySelectorAll("button.ap-sort-btn"));
+
+        let currentKey = "grants";
+        let currentDir = "desc";
+
+        function ariaFor(dir) {
+            return dir === "asc" ? "ascending" : "descending";
+        }
+
+        function compareRows(a, b, key, dir) {
+            // Pull values typed correctly for each column
+            let av;
+            let bv;
+            if (key === "rank") {
+                av = Number(a.dataset.rank);
+                bv = Number(b.dataset.rank);
+            } else if (key === "presidentName") {
+                // Tie-break by term_start_date asc within same name
+                const an = a.dataset.presidentName + a.dataset.termStart;
+                const bn = b.dataset.presidentName + b.dataset.termStart;
+                if (an < bn) return dir === "asc" ? -1 : 1;
+                if (an > bn) return dir === "asc" ? 1 : -1;
+                return 0;
+            } else {
+                av = Number(a.dataset[key]);
+                bv = Number(b.dataset[key]);
+            }
+            // Null/zero handling: null/NaN sort to bottom regardless of direction
+            const aIsNull = av === null || Number.isNaN(av);
+            const bIsNull = bv === null || Number.isNaN(bv);
+            if (aIsNull && !bIsNull) return 1;
+            if (!aIsNull && bIsNull) return -1;
+            if (aIsNull && bIsNull) return 0;
+            if (av === bv) return 0;
+            const cmp = av < bv ? -1 : 1;
+            return dir === "asc" ? cmp : -cmp;
+        }
+
+        function sortBy(key, dir) {
+            currentKey = key;
+            currentDir = dir;
+            const sorted = rows.slice().sort((a, b) => compareRows(a, b, key, dir));
+            // Re-append in the new order
+            const frag = document.createDocumentFragment();
+            sorted.forEach((row, i) => {
+                // Re-write the rank cell to reflect the visual row position
+                const rankCell = row.querySelector(".ap-rank-cell");
+                if (rankCell) rankCell.textContent = String(i + 1);
+                frag.appendChild(row);
+            });
+            tbody.appendChild(frag);
+            // Update header aria-sort + sort marks
+            buttons.forEach((btn) => {
+                const btnKey = btn.dataset.sortKey;
+                const isActive = btnKey === key;
+                btn.setAttribute("aria-sort", isActive ? ariaFor(dir) : "none");
+                const mark = btn.querySelector(".ap-sort-mark");
+                if (mark) mark.remove();
+                if (isActive) {
+                    const m = document.createElement("span");
+                    m.className = "ap-sort-mark";
+                    m.textContent = dir === "asc" ? "▲" : "▼";
+                    btn.appendChild(m);
+                }
+            });
+        }
+
+        buttons.forEach((btn) => {
+            btn.addEventListener("click", () => {
+                const key = btn.dataset.sortKey;
+                let dir;
+                if (currentKey === key) {
+                    dir = currentDir === "asc" ? "desc" : "asc";
+                } else {
+                    dir = btn.dataset.defaultDir || "desc";
+                }
+                sortBy(key, dir);
+                window.posthog?.capture("all_presidents_sorted", {
+                    column: key,
+                    direction: dir,
+                });
+            });
+        });
+
+        // Make whole rows clickable → /president/<slug>
+        tbody.addEventListener("click", (e) => {
+            const tr = e.target.closest("tr.ap-row");
+            if (!tr) return;
+            const slug = tr.dataset.slug;
+            if (!slug) return;
+            window.posthog?.capture("administration_clicked", {
+                slug,
+                source: "all_presidents",
+            });
+            window.location.href = "/president/" + slug;
+        });
+    });
+</script>
+
+<style>
+    .ap-page {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 0 40px;
+    }
+
+    /* Breadcrumb */
+    .ap-crumb {
+        padding: 28px 0 0;
+        font-size: 12px;
+        color: var(--text-muted);
+        display: flex;
+        gap: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+    }
+    .ap-crumb a {
+        color: var(--text-muted);
+        text-decoration: none;
+    }
+    .ap-crumb a:hover {
+        color: var(--text-primary);
+    }
+    .ap-crumb-sep {
+        color: var(--border-soft);
+    }
+    .ap-crumb-here {
+        color: var(--text-body);
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    /* Masthead */
+    .ap-mast {
+        padding: 32px 0 56px;
+        border-bottom: var(--rule-emphasis);
+    }
+    .ap-mast-kicker {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: var(--accent);
+        margin-bottom: 24px;
+        font-weight: 500;
+    }
+    .ap-mast-headline {
+        font-family: var(--serif);
+        font-size: 80px;
+        letter-spacing: -0.03em;
+        line-height: 0.95;
+        margin: 0 0 28px 0;
+        max-width: 920px;
+        font-weight: 400;
+        color: var(--text-primary);
+    }
+    .ap-quiet {
+        color: var(--text-faint);
+    }
+    .ap-red {
+        color: var(--accent);
+    }
+    .ap-mast-deck {
+        font-size: 17px;
+        color: var(--text-body);
+        line-height: 1.6;
+        max-width: 720px;
+        margin: 0;
+    }
+
+    /* Totals strip */
+    .ap-totals {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        border-bottom: 1px solid var(--border-default);
+    }
+    .ap-tcell {
+        padding: 32px 28px;
+        border-right: 1px solid var(--border-default);
+    }
+    .ap-tcell:first-child {
+        padding-left: 0;
+    }
+    .ap-tcell:last-child {
+        padding-right: 0;
+        border-right: none;
+    }
+    .ap-tlbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--text-faint);
+        font-weight: 500;
+        margin-bottom: 12px;
+    }
+    .ap-tbig {
+        font-family: var(--serif);
+        font-size: 56px;
+        line-height: 0.95;
+        letter-spacing: -0.025em;
+        font-variant-numeric: tabular-nums;
+        margin-bottom: 8px;
+        color: var(--text-primary);
+    }
+    .ap-tbig-accent {
+        color: var(--accent);
+    }
+    .ap-tsub {
+        font-size: 12px;
+        color: var(--text-secondary);
+        line-height: 1.5;
+    }
+
+    /* Section */
+    .ap-section {
+        padding: 56px 0;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .ap-section:last-child {
+        border-bottom: none;
+        padding-bottom: 80px;
+    }
+    .ap-section-title {
+        font-family: var(--serif);
+        font-size: 40px;
+        letter-spacing: -0.015em;
+        line-height: 1.05;
+        margin: 0 0 12px 0;
+        font-weight: 400;
+    }
+    .ap-section-deck {
+        font-size: 14px;
+        color: var(--text-secondary);
+        max-width: 640px;
+        line-height: 1.65;
+        margin: 0 0 36px 0;
+    }
+
+    /* Sortable table */
+    .ap-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+        border-top: var(--rule-emphasis);
+    }
+    .ap-table thead th {
+        text-align: left;
+        font-weight: 500;
+        padding: 0;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .ap-table thead th.ap-num,
+    .ap-table tbody td.ap-num {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+    .ap-sort-btn {
+        background: transparent;
+        border: none;
+        padding: 14px 12px;
+        font-family: inherit;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+        cursor: pointer;
+        text-align: inherit;
+        width: 100%;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        transition: color 0.15s;
+    }
+    .ap-table th.ap-num .ap-sort-btn {
+        justify-content: flex-end;
+    }
+    .ap-sort-btn:hover {
+        color: var(--text-primary);
+    }
+    .ap-sort-btn[aria-sort="ascending"],
+    .ap-sort-btn[aria-sort="descending"] {
+        color: var(--accent);
+    }
+    .ap-sort-mark {
+        font-size: 10px;
+        line-height: 1;
+        color: var(--accent);
+    }
+    .ap-table tbody tr {
+        border-bottom: 1px solid var(--border-default);
+        cursor: pointer;
+        transition: background 0.1s;
+    }
+    .ap-table tbody tr:hover {
+        background: var(--bg-muted);
+    }
+    .ap-table tbody td {
+        padding: 18px 12px;
+        vertical-align: top;
+    }
+    .ap-rank-cell {
+        font-family: var(--serif);
+        font-size: 22px;
+        color: var(--text-faint);
+        letter-spacing: -0.01em;
+        line-height: 1;
+    }
+    .ap-pres-name {
+        font-family: var(--serif);
+        font-size: 20px;
+        letter-spacing: -0.01em;
+        color: var(--text-primary);
+        line-height: 1.15;
+    }
+    .ap-pres-term {
+        font-size: 11px;
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-top: 6px;
+        font-variant-numeric: tabular-nums;
+    }
+    .ap-cell-grants {
+        font-family: var(--serif);
+        font-size: 22px;
+        letter-spacing: -0.01em;
+        color: var(--text-primary);
+    }
+    .ap-money {
+        font-family: var(--serif);
+        font-size: 18px;
+        color: var(--accent);
+        letter-spacing: -0.005em;
+    }
+    .ap-money-zero {
+        color: var(--text-ghost);
+        font-family: var(--sans);
+        font-size: 13px;
+    }
+
+    /* Stacked composition */
+    .ap-stack {
+        display: flex;
+        flex-direction: column;
+    }
+    .ap-stack-row {
+        display: grid;
+        grid-template-columns: 240px 1fr 80px;
+        gap: 20px;
+        padding: 18px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: center;
+    }
+    .ap-stack-head {
+        border-top: var(--rule-emphasis);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+        padding: 14px 0;
+    }
+    .ap-stack-head .ap-num {
+        text-align: right;
+    }
+    .ap-stack-pres {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .ap-stack-pres-name {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--text-primary);
+    }
+    .ap-stack-pres-term {
+        font-size: 11px;
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+    .ap-stack-bar {
+        height: 24px;
+        display: flex;
+        overflow: hidden;
+        background: var(--bg-muted);
+    }
+    .ap-stack-seg {
+        height: 100%;
+        transition: opacity 0.15s;
+    }
+    .ap-stack-seg:hover {
+        opacity: 0.8;
+    }
+    .ap-stack-total {
+        font-family: var(--serif);
+        font-size: 18px;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.01em;
+    }
+    .ap-stack-legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 18px;
+        margin-top: 28px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border-default);
+    }
+    .ap-stack-legend-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        color: var(--text-body);
+    }
+    .ap-stack-legend-sw {
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+    }
+    .ap-stack-legend-label {
+        text-transform: capitalize;
+    }
+
+    /* Responsive */
+    @media (max-width: 900px) {
+        .ap-page {
+            padding: 0 20px;
+        }
+        .ap-mast-headline {
+            font-size: 44px;
+        }
+        .ap-totals {
+            grid-template-columns: 1fr 1fr;
+        }
+        .ap-tcell {
+            padding: 24px 16px;
+            border-right: none;
+        }
+        .ap-tcell:nth-child(odd) {
+            padding-left: 0;
+            border-right: 1px solid var(--border-default);
+        }
+        .ap-tcell:nth-child(even) {
+            padding-right: 0;
+        }
+        .ap-tcell:nth-child(1),
+        .ap-tcell:nth-child(2) {
+            border-bottom: 1px solid var(--border-default);
+        }
+        .ap-tbig {
+            font-size: 36px;
+        }
+        .ap-section-title {
+            font-size: 28px;
+        }
+        .ap-table {
+            font-size: 12px;
+        }
+        .ap-table thead th:nth-child(4),
+        .ap-table thead th:nth-child(5),
+        .ap-table thead th:nth-child(7),
+        .ap-table tbody td:nth-child(4),
+        .ap-table tbody td:nth-child(5),
+        .ap-table tbody td:nth-child(7) {
+            display: none;
+        }
+        .ap-pres-name {
+            font-size: 15px;
+        }
+        .ap-cell-grants {
+            font-size: 16px;
+        }
+        .ap-stack-row {
+            grid-template-columns: 140px 1fr 60px;
+            gap: 12px;
+        }
+    }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -368,6 +368,8 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                             class="lb-row"
                             href={`/pardon/details/${d.slug}`}
                             data-grant-slug={d.slug}
+                            data-position={i + 1}
+                            data-restitution={d.restitution ?? 0}
                         >
                             <div class="lb-rank">{i + 1}</div>
                             <div>
@@ -477,7 +479,9 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
         document
             .querySelector('a.wire-view-all[href="/recent"]')
             ?.addEventListener("click", () => {
-                window.posthog?.capture("view_all_recent_clicked");
+                window.posthog?.capture("view_all_recent_clicked", {
+                    source: "homepage_newswire",
+                });
             });
 
         // restitution_leaderboard_clicked — leaderboard row
@@ -489,6 +493,9 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                         "restitution_leaderboard_clicked",
                         {
                             slug: row.getAttribute("data-grant-slug"),
+                            position: Number(row.getAttribute("data-position")),
+                            restitution: Number(row.getAttribute("data-restitution")),
+                            source: "homepage",
                         },
                     );
                 });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,74 +1,139 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import StatGrid from "../components/StatGrid.astro";
-import SourceBanner from "../components/SourceBanner.astro";
-import NameChip from "../components/NameChip.astro";
+import SectionHeader from "../components/SectionHeader.astro";
+import MoneyFigure from "../components/MoneyFigure.astro";
 import "../styles/global.css";
 
-const currentPath = Astro.url.pathname;
-
 import { getCollection } from "astro:content";
-import { computeStats } from "../lib/pardon-stats";
+import {
+    computeStats,
+    filterByAdministration,
+    findHeadlineAction,
+} from "../lib/pardon-stats";
 import { getAdministrationIndex } from "../lib/president-names";
+import {
+    formatCompactMoney,
+    formatGrantDateLong,
+    formatGrantDateShort,
+} from "../lib/format";
+import { getCategoryColor } from "../lib/category-colors";
+
+const currentPath = Astro.url.pathname;
+const MODERN_ERA_START = "1993-01-01";
 
 const allGrants = await getCollection("pardonDetails");
 const stats = computeStats(allGrants);
-const index = getAdministrationIndex(allGrants);
-const sortedAdmins = Array.from(index.values()).sort((a, b) =>
-    b.termStartDate.localeCompare(a.termStartDate),
+const adminIndex = getAdministrationIndex(allGrants);
+
+// Modern-era admins only (Clinton-onward), ranked by total_grants desc
+const modernAdmins = Array.from(adminIndex.values()).filter(
+    (a) => a.termStartDate >= MODERN_ERA_START,
+);
+const presidentNames = new Set(modernAdmins.map((a) => a.presidentName));
+const presidentCount = presidentNames.size;
+const modernEraStartYear = modernAdmins
+    .map((a) => a.termStartDate.slice(0, 4))
+    .sort()[0];
+
+// Per-admin enriched data for the comparison strip
+const adminRows = modernAdmins
+    .map((admin) => {
+        const adminGrants = filterByAdministration(allGrants, admin.slug);
+        const adminStats = computeStats(adminGrants);
+        const headline = findHeadlineAction(adminGrants);
+        const termEndDate = adminGrants[0]?.data.term_end_date ?? null;
+        return {
+            slug: admin.slug,
+            displayName: admin.displayName,
+            presidentName: admin.presidentName,
+            termNumber: admin.termNumber,
+            termStartDate: admin.termStartDate,
+            termEndDate,
+            grants: admin.count,
+            pardons: adminStats.totalPardons,
+            commutations: adminStats.totalCommutations,
+            restitution: adminStats.totalRestitutionAbandoned,
+            headline,
+        };
+    })
+    .sort((a, b) => b.grants - a.grants);
+
+const maxAdminGrants = Math.max(1, ...adminRows.map((a) => a.grants));
+
+// Modern-era universe used for newswire + leaderboard
+const modernEraGrants = allGrants.filter(
+    (e) => e.data.term_start_date >= MODERN_ERA_START,
 );
 
-const DATE_LIMIT = 5;
-const PER_DATE_CHIP_LIMIT = 5;
+// Newswire — 5 most recent grants
+const newswire = modernEraGrants
+    .slice()
+    .sort((a, b) => b.data.grant_date.localeCompare(a.data.grant_date))
+    .slice(0, 5);
 
-const grantsByDate = new Map<string, Array<(typeof allGrants)[number]["data"]>>();
-for (const { data } of allGrants) {
-    const bucket = grantsByDate.get(data.grant_date) ?? [];
-    bucket.push(data);
-    grantsByDate.set(data.grant_date, bucket);
+const lastUpdatedDate = newswire[0]?.data.grant_date ?? null;
+const lastUpdatedFormatted = lastUpdatedDate
+    ? formatGrantDateLong(lastUpdatedDate)
+    : null;
+
+// Restitution leaderboard — modern-era, top 10 by restitution desc
+const restitutionLeaderboard = modernEraGrants
+    .filter((e) => (e.data.restitution ?? 0) > 0)
+    .sort(
+        (a, b) => (b.data.restitution ?? 0) - (a.data.restitution ?? 0),
+    )
+    .slice(0, 10);
+
+// Category breakdown — driven by data, sorted by count desc
+const categoryEntries = Object.entries(stats.byCategory).sort(
+    ([, a], [, b]) => b - a,
+);
+const categoryTotal = categoryEntries.reduce(
+    (sum, [, count]) => sum + count,
+    0,
+);
+
+// Build-time relative stamp ("TODAY", "3D AGO", "2W AGO", ...) for the newswire
+const buildDate = new Date();
+function relativeStamp(isoDate: string): string {
+    const [y, m, d] = isoDate.split("-");
+    const grant = new Date(Number(y), Number(m) - 1, Number(d));
+    const days = Math.max(
+        0,
+        Math.floor(
+            (buildDate.getTime() - grant.getTime()) / 86_400_000,
+        ),
+    );
+    if (days === 0) return "TODAY";
+    if (days === 1) return "YESTERDAY";
+    if (days < 7) return `${days}D AGO`;
+    if (days < 30) return `${Math.floor(days / 7)}W AGO`;
+    if (days < 365) return `${Math.floor(days / 30)}MO AGO`;
+    return `${Math.floor(days / 365)}Y AGO`;
 }
 
-const recentEntries = Array.from(grantsByDate.entries())
-    .sort(([a], [b]) => b.localeCompare(a))
-    .slice(0, DATE_LIMIT)
-    .map(([date, dateGrants]) => {
-        const pardons = dateGrants.filter((g) => g.clemency_type === "pardon").length;
-        const commutations = dateGrants.length - pardons;
+function clemencyNoun(
+    type: "pardon" | "commutation",
+    count: number,
+): string {
+    if (type === "pardon") return count === 1 ? "pardon" : "pardons";
+    return count === 1 ? "commutation" : "commutations";
+}
 
-        const parts: string[] = [];
-        if (pardons > 0)
-            parts.push(`${pardons} ${pardons === 1 ? "pardon" : "pardons"}`);
-        if (commutations > 0)
-            parts.push(
-                `${commutations} ${commutations === 1 ? "commutation" : "commutations"}`,
-            );
+// Number-wall "Latest" cell composite: "Apr 23 / 2026"
+let latestMonthDay = "—";
+let latestYear = "";
+if (lastUpdatedDate) {
+    const [y, m, d] = lastUpdatedDate.split("-");
+    latestMonthDay = new Date(
+        Number(y),
+        Number(m) - 1,
+        Number(d),
+    ).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    latestYear = y;
+}
 
-        const shown = dateGrants.slice(0, PER_DATE_CHIP_LIMIT).map((g) => ({
-            name: g.recipient_name,
-            href: `/pardon/details/${g.slug}`,
-            type: g.clemency_type as "pardon" | "commutation",
-        }));
-        const overflow = dateGrants.length - shown.length;
-
-        const [y, m, d] = date.split("-");
-        const formattedDate = new Date(
-            Number(y),
-            Number(m) - 1,
-            Number(d),
-        ).toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-        });
-
-        return {
-            date: formattedDate,
-            isoDate: date,
-            grants: parts.join(", "),
-            overflow,
-            shown,
-        };
-    });
+const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`;
 ---
 
 <Layout
@@ -77,185 +142,1042 @@ const recentEntries = Array.from(grantsByDate.entries())
     ogImage="/og/home.png"
     currentPath={currentPath}
 >
-    <!-- Hero Section -->
-    <section
-        class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center"
-    >
-        <h1 class="hero-headline mb-6 max-w-3xl mx-auto">
-            Tracking Presidential Pardons
-        </h1>
-        <h2 class="hero-subtitle mb-8">Since William Jefferson Clinton</h2>
-        <StatGrid stats={stats} animated={true} />
-    </section>
+    <main class="bold-home">
+        <!-- HERO -->
+        <section class="hero-bold">
+            <div class="eyebrow">{heroEyebrow}</div>
+            <h1 class="hero-headline-bold">
+                <span class="quiet">{stats.totalGrants.toLocaleString()}</span> grants.
+                <br />
+                <span class="red">
+                    {formatCompactMoney(stats.totalRestitutionAbandoned)}
+                </span> in restitution forgiven.
+                <br />
+                {presidentCount} presidents.
+            </h1>
+            <p class="hero-deck">
+                A complete public record of federal pardons and commutations,
+                sourced directly from the Department of Justice. Compare
+                administrations side-by-side, follow the dollars owed to
+                victims, and read every original warrant.
+            </p>
 
-    <!-- Gradient Divider -->
-    <div class="max-w-home mx-auto px-5 md:px-10">
-        <div class="divider-gradient"></div>
-    </div>
-
-    <!-- Administrations Section -->
-    <section
-        class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto"
-        data-animate
-    >
-        <h2 class="text-section font-serif text-text-primary mb-2">
-            By Administration
-        </h2>
-        <p class="text-nav text-text-faint mb-10">
-            Select an administration to explore its clemency record
-        </p>
-        <div
-            class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-grid"
-        >
-            {
-                sortedAdmins.map((admin) => (
-                    <a
-                        href={`/president/${admin.slug}`}
-                        class="category-card hover:bg-muted transition-colors"
-                        style="border-left-color: var(--color-accent);"
-                    >
-                        <span
-                            class="category-count"
-                            style="color: var(--color-accent);"
-                        >
-                            {admin.count.toLocaleString()}
-                        </span>
-                        <span class="text-nav text-text-body">
-                            {admin.displayName}
-                        </span>
-                    </a>
-                ))
-            }
-        </div>
-    </section>
-
-    <!-- Flat Divider -->
-    <div class="max-w-home mx-auto px-5 md:px-10">
-        <div class="divider-flat"></div>
-    </div>
-
-    <!-- Recent Pardons Section -->
-    <section
-        class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto"
-        data-animate
-    >
-        <h2 class="text-section font-serif text-text-primary mb-2">
-            Recent Pardons &amp; Commutations
-        </h2>
-        <p class="text-nav text-text-faint mb-10">
-            The most recent executive clemency actions
-        </p>
-        <div class="space-y-8">
-            {
-                recentEntries.map((entry) => (
-                    <div>
-                        <div
-                            class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4 mb-1.5"
-                        >
-                            <a
-                                class="timeline-date timeline-date-link no-underline"
-                                href={`/search?date=${entry.isoDate}`}
-                                data-iso-date={entry.isoDate}
-                            >
-                                {entry.date}
-                            </a>
-                            <span class="timeline-grants-badge inline-block w-fit">
-                                {entry.grants}
-                            </span>
-                        </div>
-                        <div class="flex flex-wrap items-center gap-1.5">
-                            {entry.shown.map(({ name, href, type }) => (
-                                <NameChip
-                                    name={name}
-                                    href={href}
-                                    type={type}
-                                />
-                            ))}
-                            {entry.overflow > 0 && (
-                                <a
-                                    class="recent-overflow-note no-underline"
-                                    href={`/search?date=${entry.isoDate}`}
-                                    data-iso-date={entry.isoDate}
-                                >
-                                    +{entry.overflow} more — view this date and earlier →
-                                </a>
-                            )}
-                        </div>
+            <div class="numwall">
+                <div class="nw">
+                    <div class="nw-lbl">Total grants</div>
+                    <div class="nw-big">
+                        {stats.totalGrants.toLocaleString()}
                     </div>
-                ))
-            }
-        </div>
-    </section>
+                    <div class="nw-sub">
+                        Pardons and commutations issued since January 20, {modernEraStartYear}.
+                    </div>
+                </div>
+                <div class="nw">
+                    <div class="nw-lbl">Restitution</div>
+                    <div class="nw-big nw-accent">
+                        {formatCompactMoney(stats.totalRestitutionAbandoned)}
+                    </div>
+                    <div class="nw-sub">
+                        Owed to victims of crime, written off by clemency.
+                    </div>
+                </div>
+                <div class="nw">
+                    <div class="nw-lbl">Administrations</div>
+                    <div class="nw-big">{adminRows.length}</div>
+                    <div class="nw-sub">
+                        Across {presidentCount} presidents in the modern era.
+                    </div>
+                </div>
+                <div class="nw">
+                    <div class="nw-lbl">Latest</div>
+                    <div class="nw-latest">
+                        <span class="nw-latest-md">{latestMonthDay}</span>
+                        <span class="nw-latest-yr">{latestYear}</span>
+                    </div>
+                    <div class="nw-sub">
+                        {lastUpdatedFormatted ? `Last grant on ${lastUpdatedFormatted}.` : "—"}
+                    </div>
+                </div>
+            </div>
+        </section>
 
-    <!-- Flat Divider -->
-    <div class="max-w-home mx-auto px-5 md:px-10">
-        <div class="divider-flat"></div>
-    </div>
+        <!-- NEWSWIRE TICKER -->
+        <section class="page-section">
+            <div class="wire">
+                <div class="wire-head">
+                    <div class="wire-head-left">
+                        <span class="wire-stamp">
+                            <span class="wire-stamp-dot"></span>Recent
+                        </span>
+                        <h3 class="wire-title">Recent grants</h3>
+                    </div>
+                    <div class="wire-head-right">
+                        {lastUpdatedFormatted && (
+                            <span>
+                                Updated <span class="wire-updated">
+                                    {lastUpdatedFormatted}
+                                </span>
+                            </span>
+                        )}
+                        <a href="/recent" class="wire-view-all">
+                            View all recent →
+                        </a>
+                    </div>
+                </div>
+                <div class="wire-list">
+                    {newswire.map((entry) => {
+                        const d = entry.data;
+                        const adminDisplay = adminIndex.get(d.administration_slug)?.displayName ?? d.president_name;
+                        const lastName = d.president_name.split(" ").slice(-1)[0];
+                        const restitution = d.restitution ?? 0;
+                        const typeLabel = d.clemency_type === "pardon" ? "Pardon" : "Commutation";
+                        return (
+                            <a
+                                class="wire-item"
+                                href={`/pardon/details/${d.slug}`}
+                                data-grant-date={d.grant_date}
+                                data-grant-slug={d.slug}
+                            >
+                                <div class="wire-stamp-time">
+                                    <span class="wire-when">
+                                        {relativeStamp(d.grant_date)}
+                                    </span>
+                                    {formatGrantDateShort(d.grant_date)}
+                                </div>
+                                <div class="wire-body">
+                                    <div class="wire-who">
+                                        {d.recipient_name}
+                                        <span class="wire-type">{typeLabel}</span>
+                                    </div>
+                                    <div class="wire-what">
+                                        {d.offense}
+                                        {d.district && ` · ${d.district}`}
+                                    </div>
+                                </div>
+                                <div class="wire-pres">
+                                    {lastName}
+                                    <span class="wire-pres-term">
+                                        {adminDisplay}
+                                    </span>
+                                </div>
+                                <div class:list={["wire-money", restitution === 0 && "wire-money-zero"]}>
+                                    {restitution > 0 ? formatCompactMoney(restitution) : "no restitution"}
+                                </div>
+                                <div class="wire-arr" aria-hidden="true">→</div>
+                            </a>
+                        );
+                    })}
+                </div>
+            </div>
+        </section>
 
-    <!-- Search CTA -->
-    <section
-        class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto text-center"
-        data-animate
-    >
-        <h2 class="text-section font-serif text-text-primary mb-4">
-            Explore the Data
-        </h2>
-        <p class="text-nav text-text-faint mb-8">
-            Search, filter, and explore all {stats.totalGrants.toLocaleString()} clemency
-            grants
-        </p>
-        <a href="/search" class="load-more-btn inline-block no-underline">
-            Search all pardons →
-        </a>
-    </section>
+        <!-- BY-ADMINISTRATION COMPARISON STRIP -->
+        <section class="page-section page-section-pad">
+            <SectionHeader
+                title="By administration."
+                deck="Ranked by total grants. The bar shows scale; the figure on the right shows restitution forgiven — money owed to victims that recipients no longer have to pay back."
+            />
+            <div class="cb-list">
+                {adminRows.map((admin, i) => {
+                    const pct = (admin.grants / maxAdminGrants) * 100;
+                    const annotation = admin.headline
+                        ? `Includes ${admin.headline.count.toLocaleString()} ${admin.headline.category} ${clemencyNoun(admin.headline.clemencyType, admin.headline.count)} on ${formatGrantDateShort(admin.headline.date)}.`
+                        : null;
+                    const yearRange = admin.termEndDate
+                        ? `${admin.termStartDate.slice(0, 4)}–${admin.termEndDate.slice(0, 4)}`
+                        : `${admin.termStartDate.slice(0, 4)}–`;
+                    return (
+                        <a
+                            class="cb-row"
+                            href={`/president/${admin.slug}`}
+                            data-admin-slug={admin.slug}
+                        >
+                            <div class="cb-rank">{i + 1}</div>
+                            <div class="cb-pres">
+                                <div class="cb-name">{admin.displayName}</div>
+                                <div class="cb-yr">{yearRange}</div>
+                            </div>
+                            <div class="cb-bar-wrap">
+                                <div class="cb-barlbl">
+                                    <span>Grants</span>
+                                    <span class="cb-count">
+                                        {admin.grants.toLocaleString()}
+                                    </span>
+                                </div>
+                                <div class="cb-bar">
+                                    <div
+                                        class="cb-bar-fill"
+                                        style={`width:${pct}%;`}
+                                    />
+                                </div>
+                                {annotation && (
+                                    <div class="cb-annotation">
+                                        {annotation}
+                                    </div>
+                                )}
+                            </div>
+                            <div class="cb-money-cell">
+                                <MoneyFigure
+                                    value={formatCompactMoney(admin.restitution)}
+                                    label="Restitution"
+                                    sizeClass="text-section"
+                                    align="right"
+                                    muted={admin.restitution === 0}
+                                />
+                            </div>
+                            <div class="cb-arrow" aria-hidden="true">→</div>
+                        </a>
+                    );
+                })}
+            </div>
+        </section>
 
-    <!-- Source Banner -->
-    <section class="max-w-source mx-auto px-5 md:px-8 mb-10">
-        <SourceBanner />
-    </section>
+        <!-- CALLOUT -->
+        <section class="page-section">
+            <div class="callout">
+                <div class="callout-label">Combined impact</div>
+                <p class="callout-text">
+                    Across {presidentCount} presidents, federal clemency has
+                    erased <span class="callout-red">
+                        {formatCompactMoney(stats.totalRestitutionAbandoned)}
+                    </span> in court-ordered restitution — money owed to <span class="callout-red">
+                        victims of crime
+                    </span> that they will not recover.
+                </p>
+            </div>
+        </section>
+
+        <!-- RESTITUTION LEADERBOARD -->
+        <section class="page-section page-section-pad">
+            <SectionHeader
+                title="Largest restitution forgiven."
+                deck="The single grants representing the most money owed to victims that no longer has to be paid back. Court-ordered restitution figures from the original DOJ warrant."
+            />
+            <div class="lb-bold">
+                <div class="lb-row lb-head">
+                    <div class="lb-rank-cell">#</div>
+                    <div>Recipient · Offense</div>
+                    <div>President</div>
+                    <div class="lb-money-head">Restitution</div>
+                </div>
+                {restitutionLeaderboard.map((entry, i) => {
+                    const d = entry.data;
+                    const adminDisplay = adminIndex.get(d.administration_slug)?.displayName ?? d.president_name;
+                    return (
+                        <a
+                            class="lb-row"
+                            href={`/pardon/details/${d.slug}`}
+                            data-grant-slug={d.slug}
+                        >
+                            <div class="lb-rank">{i + 1}</div>
+                            <div>
+                                <div class="lb-name">{d.recipient_name}</div>
+                                <div class="lb-offense">
+                                    {d.offense}
+                                    {d.district && ` · ${d.district}`}
+                                </div>
+                            </div>
+                            <div class="lb-pres">
+                                {adminDisplay}
+                                <span class="lb-date">
+                                    {formatGrantDateShort(d.grant_date)}
+                                </span>
+                            </div>
+                            <div class="lb-money">
+                                {formatCompactMoney(d.restitution)}
+                            </div>
+                        </a>
+                    );
+                })}
+            </div>
+        </section>
+
+        <!-- CATEGORY BREAKDOWN -->
+        <section class="page-section page-section-pad">
+            <SectionHeader
+                title="By offense category."
+                deck="Categories are derived from the original DOJ warrant text. Counts reflect every grant in the dataset."
+            />
+            <div class="cat-list">
+                {categoryEntries.map(([category, count]) => {
+                    const pct = (count / categoryTotal) * 100;
+                    const color = getCategoryColor(category);
+                    const label = category.replace(/\b\w/g, (c) =>
+                        c.toUpperCase(),
+                    );
+                    return (
+                        <a
+                            class="cat-row"
+                            href={`/search?categories=${encodeURIComponent(category)}`}
+                            data-category={category}
+                        >
+                            <div class="cat-num" style={`color:${color};`}>
+                                {count.toLocaleString()}
+                            </div>
+                            <div class="cat-label">{label}</div>
+                            <div class="cat-bar-cell">
+                                <div class="cat-pct-bar">
+                                    <div
+                                        class="cat-pct-fill"
+                                        style={`width:${pct}%; background:${color};`}
+                                    />
+                                </div>
+                                <div class="cat-pct">{pct.toFixed(1)}%</div>
+                            </div>
+                        </a>
+                    );
+                })}
+            </div>
+        </section>
+
+        <!-- SOURCE BAND -->
+        <section class="page-section page-section-pad">
+            <div class="source-band">
+                <p>
+                    All data is drawn from the
+                    <strong>DOJ Office of the Pardon Attorney</strong>. Every
+                    grant page links to the original warrant PDF. Pardonned is
+                    not affiliated with the U.S. government.
+                </p>
+                <a href="/search" class="source-band-cta">
+                    Search all {stats.totalGrants.toLocaleString()} grants →
+                </a>
+            </div>
+        </section>
+    </main>
 </Layout>
-
-<script src="/scripts/animate-on-scroll.js" is:inline></script>
 
 <script is:inline>
     document.addEventListener("DOMContentLoaded", () => {
-        // Track administration card clicks
-        document.querySelectorAll('a[href^="/president/"]').forEach((card) => {
-            card.addEventListener("click", () => {
-                const slug = card
-                    .getAttribute("href")
-                    ?.replace("/president/", "");
-                window.posthog?.capture("administration_clicked", { slug });
+        // administration_clicked — comparison strip row
+        document.querySelectorAll("a.cb-row[data-admin-slug]").forEach((row) => {
+            row.addEventListener("click", () => {
+                window.posthog?.capture("administration_clicked", {
+                    slug: row.getAttribute("data-admin-slug"),
+                    source: "comparison_strip",
+                });
             });
         });
 
-        // Track "Search all pardons" CTA click
+        // recent_date_clicked — newswire item (port of the legacy event;
+        // payload includes the grant_date plus the slug)
         document
-            .querySelector('a[href="/search"].load-more-btn')
-            ?.addEventListener("click", () => {
-                window.posthog?.capture("search_all_pardons_clicked");
-            });
-
-        // Track Recent section date label clicks
-        document
-            .querySelectorAll("a.timeline-date-link[data-iso-date]")
-            .forEach((link) => {
-                link.addEventListener("click", () => {
+            .querySelectorAll("a.wire-item[data-grant-date]")
+            .forEach((item) => {
+                item.addEventListener("click", () => {
                     window.posthog?.capture("recent_date_clicked", {
-                        date: link.getAttribute("data-iso-date"),
+                        date: item.getAttribute("data-grant-date"),
+                        slug: item.getAttribute("data-grant-slug"),
+                        source: "newswire",
                     });
                 });
             });
 
-        // Track Recent section overflow link clicks
+        // view_all_recent_clicked — wire-head "View all recent →"
         document
-            .querySelectorAll("a.recent-overflow-note[data-iso-date]")
-            .forEach((link) => {
-                link.addEventListener("click", () => {
-                    window.posthog?.capture("recent_overflow_clicked", {
-                        date: link.getAttribute("data-iso-date"),
+            .querySelector('a.wire-view-all[href="/recent"]')
+            ?.addEventListener("click", () => {
+                window.posthog?.capture("view_all_recent_clicked");
+            });
+
+        // restitution_leaderboard_clicked — leaderboard row
+        document
+            .querySelectorAll("a.lb-row[data-grant-slug]")
+            .forEach((row) => {
+                row.addEventListener("click", () => {
+                    window.posthog?.capture(
+                        "restitution_leaderboard_clicked",
+                        {
+                            slug: row.getAttribute("data-grant-slug"),
+                        },
+                    );
+                });
+            });
+
+        // category_clicked — category breakdown row
+        document
+            .querySelectorAll("a.cat-row[data-category]")
+            .forEach((row) => {
+                row.addEventListener("click", () => {
+                    window.posthog?.capture("category_clicked", {
+                        category: row.getAttribute("data-category"),
+                        source: "homepage",
                     });
+                });
+            });
+
+        // search_all_pardons_clicked — source-band CTA (legacy continuity)
+        document
+            .querySelector("a.source-band-cta[href='/search']")
+            ?.addEventListener("click", () => {
+                window.posthog?.capture("search_all_pardons_clicked", {
+                    source: "homepage_source_band",
                 });
             });
     });
 </script>
+
+<style>
+    .bold-home {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 0 40px;
+    }
+
+    .page-section {
+        padding: 0;
+    }
+    .page-section-pad {
+        padding: 0 0 80px;
+    }
+
+    /* HERO */
+    .hero-bold {
+        padding: 56px 0 0;
+    }
+    .eyebrow {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: var(--accent);
+        font-weight: 500;
+        margin-bottom: 28px;
+    }
+    .hero-headline-bold {
+        font-family: var(--serif);
+        font-size: var(--text-display-xl);
+        line-height: 0.98;
+        letter-spacing: -0.025em;
+        margin: 0 0 32px 0;
+        max-width: 980px;
+        font-weight: 400;
+        color: var(--text-primary);
+    }
+    .hero-headline-bold .quiet {
+        color: var(--text-faint);
+    }
+    .hero-headline-bold .red {
+        color: var(--accent);
+    }
+    .hero-deck {
+        font-size: 18px;
+        color: var(--text-body);
+        max-width: 620px;
+        line-height: 1.65;
+        margin: 0 0 56px 0;
+    }
+
+    /* NUMBER WALL */
+    .numwall {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr 1fr 1fr;
+        border-top: var(--rule-emphasis);
+        padding-top: 28px;
+        margin-bottom: 80px;
+        gap: 0;
+    }
+    .nw {
+        padding: 0 24px;
+        border-right: 1px solid var(--border-default);
+    }
+    .nw:first-child {
+        padding-left: 0;
+    }
+    .nw:last-child {
+        border-right: none;
+    }
+    .nw-lbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--text-faint);
+        font-weight: 500;
+        margin-bottom: 10px;
+    }
+    .nw-big {
+        font-family: var(--serif);
+        font-size: var(--text-display-lg);
+        line-height: 0.95;
+        letter-spacing: -0.025em;
+        margin-bottom: 8px;
+        font-variant-numeric: tabular-nums;
+        color: var(--text-primary);
+    }
+    .nw-accent {
+        color: var(--accent);
+    }
+    .nw-sub {
+        font-size: 12px;
+        color: var(--text-secondary);
+        line-height: 1.5;
+    }
+    .nw-latest {
+        font-family: var(--serif);
+        line-height: 1.05;
+        margin-bottom: 8px;
+    }
+    .nw-latest-md {
+        font-size: 32px;
+        letter-spacing: -0.02em;
+        display: block;
+        font-variant-numeric: tabular-nums;
+    }
+    .nw-latest-yr {
+        font-size: 18px;
+        color: var(--text-faint);
+        font-variant-numeric: tabular-nums;
+    }
+
+    /* NEWSWIRE */
+    .wire {
+        border-top: var(--rule-emphasis);
+        border-bottom: 1px solid var(--border-default);
+        margin: 0 0 80px;
+        background: var(--bg-card);
+    }
+    .wire-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 0;
+        border-bottom: 1px solid var(--border-default);
+        gap: 24px;
+        flex-wrap: wrap;
+    }
+    .wire-head-left {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+    }
+    .wire-stamp {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--accent);
+        padding: 4px 10px;
+        background: var(--accent-tint);
+        border-radius: 2px;
+    }
+    .wire-stamp-dot {
+        width: 6px;
+        height: 6px;
+        background: var(--accent);
+        border-radius: 50%;
+    }
+    .wire-title {
+        font-family: var(--serif);
+        font-size: 24px;
+        letter-spacing: -0.01em;
+        margin: 0;
+        font-weight: 400;
+    }
+    .wire-head-right {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+    }
+    .wire-updated {
+        color: var(--text-body);
+        text-transform: none;
+        letter-spacing: 0;
+    }
+    .wire-view-all {
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-border);
+        padding-bottom: 1px;
+    }
+    .wire-view-all:hover {
+        border-bottom-color: var(--accent);
+    }
+
+    .wire-list {
+        display: flex;
+        flex-direction: column;
+    }
+    .wire-item {
+        display: grid;
+        grid-template-columns: 110px 1fr 200px 110px 24px;
+        gap: 24px;
+        padding: 16px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: center;
+        text-decoration: none;
+        color: var(--text-primary);
+        transition: background 0.15s;
+    }
+    .wire-item:last-child {
+        border-bottom: none;
+    }
+    .wire-item:hover {
+        background: var(--bg-page);
+    }
+    .wire-stamp-time {
+        font-size: 11px;
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-variant-numeric: tabular-nums;
+        line-height: 1.4;
+    }
+    .wire-when {
+        color: var(--accent);
+        display: block;
+        font-weight: 600;
+    }
+    .wire-who {
+        font-family: var(--serif);
+        font-size: 19px;
+        letter-spacing: -0.005em;
+        line-height: 1.2;
+    }
+    .wire-type {
+        font-size: 11px;
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-left: 8px;
+        font-family: var(--sans);
+    }
+    .wire-what {
+        font-size: 12px;
+        color: var(--text-secondary);
+        margin-top: 4px;
+        line-height: 1.5;
+    }
+    .wire-pres {
+        font-size: 12px;
+        color: var(--text-body);
+    }
+    .wire-pres-term {
+        font-size: 10px;
+        color: var(--text-faint);
+        display: block;
+        margin-top: 2px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+    .wire-money {
+        text-align: right;
+        font-family: var(--serif);
+        font-size: 17px;
+        color: var(--accent);
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.005em;
+    }
+    .wire-money-zero {
+        color: var(--text-ghost);
+        font-family: var(--sans);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+    .wire-arr {
+        color: var(--text-faint);
+        text-align: right;
+    }
+
+    /* BY-ADMINISTRATION COMPARISON */
+    .cb-list {
+        border-top: 1px solid var(--border-default);
+    }
+    .cb-row {
+        display: grid;
+        grid-template-columns: 60px 280px 1fr 180px 24px;
+        gap: 28px;
+        padding: 22px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: center;
+        text-decoration: none;
+        color: var(--text-primary);
+        transition: background 0.15s;
+    }
+    .cb-row:hover {
+        background: var(--bg-muted);
+    }
+    .cb-rank {
+        font-family: var(--serif);
+        font-size: 36px;
+        color: var(--text-faint);
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.02em;
+    }
+    .cb-name {
+        font-family: var(--serif);
+        font-size: 24px;
+        letter-spacing: -0.01em;
+        line-height: 1.15;
+    }
+    .cb-yr {
+        font-size: 12px;
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin-top: 6px;
+        font-variant-numeric: tabular-nums;
+    }
+    .cb-bar-wrap {
+        padding-right: 12px;
+    }
+    .cb-barlbl {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-size: 12px;
+        color: var(--text-faint);
+        margin-bottom: 6px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+    }
+    .cb-count {
+        font-family: var(--serif);
+        font-size: 22px;
+        color: var(--text-primary);
+        text-transform: none;
+        letter-spacing: -0.01em;
+        font-variant-numeric: tabular-nums;
+    }
+    .cb-bar {
+        height: 10px;
+        background: var(--bg-muted);
+        position: relative;
+    }
+    .cb-bar-fill {
+        height: 100%;
+        background: var(--text-primary);
+    }
+    .cb-annotation {
+        margin-top: 10px;
+        font-size: 12px;
+        color: var(--text-faint);
+        font-style: italic;
+        line-height: 1.5;
+    }
+    .cb-money-cell {
+        display: flex;
+        justify-content: flex-end;
+    }
+    .cb-arrow {
+        color: var(--text-faint);
+        text-align: right;
+        font-size: 18px;
+    }
+
+    /* CALLOUT */
+    .callout {
+        background: var(--accent-tint);
+        border-top: var(--rule-accent);
+        padding: 56px 56px 48px;
+        margin: 0 0 80px;
+    }
+    .callout-label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: var(--accent);
+        font-weight: 500;
+        margin-bottom: 24px;
+    }
+    .callout-text {
+        font-family: var(--serif);
+        font-size: var(--text-display);
+        line-height: 1.2;
+        letter-spacing: -0.015em;
+        color: var(--text-primary);
+        max-width: 880px;
+        margin: 0;
+    }
+    .callout-red {
+        color: var(--accent);
+    }
+
+    /* LEADERBOARD */
+    .lb-bold {
+        border-top: var(--rule-emphasis);
+    }
+    .lb-row {
+        display: grid;
+        grid-template-columns: 60px 1fr 180px 200px;
+        gap: 24px;
+        padding: 22px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: baseline;
+        text-decoration: none;
+        color: var(--text-primary);
+        transition: background 0.15s;
+    }
+    .lb-row:hover:not(.lb-head) {
+        background: var(--bg-muted);
+    }
+    .lb-head {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+        padding: 10px 0 14px;
+    }
+    .lb-head:hover {
+        background: transparent;
+    }
+    .lb-rank-cell {
+        text-align: right;
+    }
+    .lb-rank {
+        font-family: var(--serif);
+        font-size: 18px;
+        color: var(--text-faint);
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+    .lb-name {
+        font-size: 16px;
+        font-weight: 500;
+        letter-spacing: -0.005em;
+    }
+    .lb-offense {
+        font-size: 13px;
+        color: var(--text-secondary);
+        margin-top: 4px;
+        line-height: 1.5;
+    }
+    .lb-pres {
+        font-size: 13px;
+        color: var(--text-muted);
+    }
+    .lb-date {
+        color: var(--text-faint);
+        display: block;
+        font-size: 12px;
+        margin-top: 2px;
+        font-variant-numeric: tabular-nums;
+    }
+    .lb-money {
+        font-family: var(--serif);
+        font-size: 32px;
+        color: var(--accent);
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.015em;
+        line-height: 1;
+    }
+    .lb-money-head {
+        text-align: right;
+    }
+
+    /* CATEGORY LIST */
+    .cat-list {
+        border-top: 1px solid var(--border-default);
+    }
+    .cat-row {
+        display: grid;
+        grid-template-columns: 100px 1fr 240px;
+        gap: 20px;
+        padding: 18px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: center;
+        text-decoration: none;
+        color: var(--text-primary);
+        transition: background 0.15s;
+    }
+    .cat-row:hover {
+        background: var(--bg-muted);
+    }
+    .cat-num {
+        font-family: var(--serif);
+        font-size: 28px;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.01em;
+    }
+    .cat-label {
+        font-size: 16px;
+        font-weight: 500;
+        text-transform: capitalize;
+    }
+    .cat-bar-cell {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .cat-pct-bar {
+        flex: 1;
+        height: 4px;
+        background: var(--bg-muted);
+        position: relative;
+    }
+    .cat-pct-fill {
+        height: 100%;
+    }
+    .cat-pct {
+        font-size: 11px;
+        color: var(--text-faint);
+        font-variant-numeric: tabular-nums;
+        min-width: 40px;
+        text-align: right;
+    }
+
+    /* SOURCE BAND */
+    .source-band {
+        border-top: 1px solid var(--border-default);
+        padding: 32px 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 32px;
+        flex-wrap: wrap;
+    }
+    .source-band p {
+        font-size: 13px;
+        color: var(--text-secondary);
+        max-width: 580px;
+        margin: 0;
+        line-height: 1.6;
+    }
+    .source-band strong {
+        color: var(--text-primary);
+        font-weight: 500;
+    }
+    .source-band-cta {
+        font-size: 13px;
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-border);
+        padding-bottom: 1px;
+    }
+    .source-band-cta:hover {
+        border-bottom-color: var(--accent);
+    }
+
+    /* RESPONSIVE */
+    @media (max-width: 900px) {
+        .bold-home {
+            padding: 0 20px;
+        }
+        .hero-headline-bold {
+            font-size: 48px;
+        }
+        .hero-deck {
+            font-size: 16px;
+            margin-bottom: 40px;
+        }
+        .numwall {
+            grid-template-columns: 1fr 1fr;
+            row-gap: 28px;
+            margin-bottom: 60px;
+        }
+        .nw {
+            padding: 0 16px;
+            border-right: none;
+        }
+        .nw:nth-child(odd) {
+            padding-left: 0;
+        }
+        .nw:nth-child(even) {
+            padding-right: 0;
+        }
+        .nw-big {
+            font-size: 44px;
+        }
+
+        .wire-item {
+            grid-template-columns: 1fr;
+            gap: 6px;
+            padding: 18px 0;
+        }
+        .wire-arr,
+        .wire-pres {
+            display: none;
+        }
+        .wire-money {
+            text-align: left;
+        }
+
+        .cb-row {
+            grid-template-columns: 40px 1fr;
+            grid-template-areas:
+                "rank pres"
+                ".    bar"
+                ".    money"
+                ".    annotation";
+            row-gap: 12px;
+            gap: 16px;
+            padding: 22px 0;
+        }
+        .cb-rank {
+            grid-area: rank;
+            font-size: 24px;
+        }
+        .cb-pres {
+            grid-area: pres;
+        }
+        .cb-bar-wrap {
+            grid-area: bar;
+        }
+        .cb-money-cell {
+            grid-area: money;
+            justify-content: flex-start;
+        }
+        .cb-arrow {
+            display: none;
+        }
+        .cb-annotation {
+            grid-area: annotation;
+        }
+
+        .callout {
+            padding: 36px 24px 32px;
+            margin-bottom: 60px;
+        }
+        .callout-text {
+            font-size: 24px;
+        }
+
+        .lb-row {
+            grid-template-columns: 32px 1fr 110px;
+            row-gap: 4px;
+            padding: 18px 0;
+        }
+        .lb-row.lb-head {
+            display: none;
+        }
+        .lb-pres {
+            grid-column: 2 / 3;
+            grid-row: 2;
+        }
+        .lb-money {
+            grid-column: 3 / 4;
+            grid-row: 1 / 3;
+            font-size: 22px;
+            align-self: center;
+        }
+        .lb-money-head {
+            display: none;
+        }
+
+        .cat-row {
+            grid-template-columns: 80px 1fr;
+            grid-template-areas:
+                "num label"
+                "num bar";
+            row-gap: 6px;
+        }
+        .cat-num {
+            grid-area: num;
+            font-size: 24px;
+        }
+        .cat-label {
+            grid-area: label;
+        }
+        .cat-bar-cell {
+            grid-area: bar;
+        }
+    }
+</style>

--- a/src/pages/og/all-presidents.png.ts
+++ b/src/pages/og/all-presidents.png.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { computeStats } from "../../lib/pardon-stats";
+import { getAdministrationIndex } from "../../lib/president-names";
+import { renderOgImage } from "../../lib/og-image";
+import { formatCompactMoney } from "../../lib/format";
+
+export const prerender = true;
+
+const MODERN_ERA_START = "1993-01-01";
+
+export const GET: APIRoute = async () => {
+  const allGrants = await getCollection("pardonDetails");
+  const modernEraGrants = allGrants.filter(
+    (e) => e.data.term_start_date >= MODERN_ERA_START,
+  );
+  const stats = computeStats(modernEraGrants);
+  const adminIndex = getAdministrationIndex(modernEraGrants);
+
+  const png = await renderOgImage({
+    title: "All presidents.",
+    subtitle: "Cross-administration clemency comparison since 1993.",
+    stat: formatCompactMoney(stats.totalRestitutionAbandoned),
+    statLabel: `${adminIndex.size} terms · ${stats.totalGrants.toLocaleString()} grants`,
+    accent: true,
+  });
+
+  return new Response(png as unknown as BodyInit, {
+    headers: { "Content-Type": "image/png" },
+  });
+};

--- a/src/pages/og/recent.png.ts
+++ b/src/pages/og/recent.png.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { renderOgImage } from "../../lib/og-image";
+import { getCurrentAdministration } from "../../lib/president-names";
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+  const allGrants = await getCollection("pardonDetails");
+
+  // Scope: current administration only, matching /recent.
+  const currentAdmin = getCurrentAdministration(allGrants);
+  const currentGrants = currentAdmin
+    ? allGrants.filter((e) => e.data.administration_slug === currentAdmin.slug)
+    : [];
+
+  const adminLabel = currentAdmin?.displayName ?? "the current administration";
+
+  const png = await renderOgImage({
+    title: "Recent clemency.",
+    subtitle: adminLabel,
+    stat: `${currentGrants.length}`,
+    statLabel:
+      currentGrants.length === 1
+        ? "Grant in this term"
+        : "Grants in this term",
+    accent: false,
+  });
+
+  return new Response(png as unknown as BodyInit, {
+    headers: { "Content-Type": "image/png" },
+  });
+};

--- a/src/pages/pardon/details/[slug].astro
+++ b/src/pages/pardon/details/[slug].astro
@@ -434,6 +434,7 @@ const ogImagePath = `/og/${data.slug}.png`;
                         href={`/pardon/details/${older.slug}`}
                         class="db-foot-link"
                         data-direction="older"
+                        data-to-slug={older.slug}
                     >
                         <span class="db-foot-arrow" aria-hidden="true">←</span>
                         <span class="db-foot-stack">
@@ -464,6 +465,7 @@ const ogImagePath = `/og/${data.slug}.png`;
                         href={`/pardon/details/${newer.slug}`}
                         class="db-foot-link db-foot-link-right"
                         data-direction="newer"
+                        data-to-slug={newer.slug}
                     >
                         <span class="db-foot-stack">
                             <span class="db-foot-label">Next</span>
@@ -506,8 +508,8 @@ const ogImagePath = `/og/${data.slug}.png`;
         document.querySelectorAll("a.db-doc-link").forEach((link) => {
             link.addEventListener("click", () => {
                 window.posthog?.capture("source_document_clicked", {
+                    slug: grantSlug,
                     name: recipientName,
-                    url: link.href,
                 });
             });
         });
@@ -519,6 +521,7 @@ const ogImagePath = `/og/${data.slug}.png`;
                 link.addEventListener("click", () => {
                     window.posthog?.capture("pardon_neighbor_clicked", {
                         from_slug: grantSlug,
+                        to_slug: link.getAttribute("data-to-slug"),
                         direction: link.getAttribute("data-direction"),
                     });
                 });

--- a/src/pages/pardon/details/[slug].astro
+++ b/src/pages/pardon/details/[slug].astro
@@ -1,69 +1,87 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
-import StatCard from "../../../components/StatCard.astro";
+import MoneyFigure from "../../../components/MoneyFigure.astro";
 import "../../../styles/global.css";
 import { getCollection } from "astro:content";
 import { resolveUrl } from "../../../lib/parsers/types";
 import { generateBreadcrumbJsonLd } from "../../../lib/seo";
+import { getAdministrationIndex } from "../../../lib/president-names";
+import {
+    formatCompactMoney,
+    formatCurrencyPrecise,
+    formatGrantDateLong,
+    formatGrantDateShort,
+    formatSentenceCompact,
+    formatSentenceMonths,
+} from "../../../lib/format";
 
 export async function getStaticPaths() {
     const allPardons = await getCollection("pardonDetails");
 
-    return allPardons.map((grant) => ({
-        params: { slug: grant.data.slug },
-        props: { grant },
-    }));
+    // Group by administration so we can wire prev/next links within each admin
+    const byAdmin = new Map<string, typeof allPardons>();
+    for (const p of allPardons) {
+        const slug = p.data.administration_slug;
+        if (!byAdmin.has(slug)) byAdmin.set(slug, []);
+        byAdmin.get(slug)!.push(p);
+    }
+    // Date-desc within each admin; recipient_name as stable tiebreaker
+    for (const list of byAdmin.values()) {
+        list.sort((a, b) => {
+            const dc = b.data.grant_date.localeCompare(a.data.grant_date);
+            if (dc !== 0) return dc;
+            return a.data.recipient_name.localeCompare(b.data.recipient_name);
+        });
+    }
+
+    const adminIndex = getAdministrationIndex(allPardons);
+
+    return allPardons.map((grant) => {
+        const adminList = byAdmin.get(grant.data.administration_slug)!;
+        const i = adminList.findIndex((p) => p.id === grant.id);
+        const newer = i > 0 ? adminList[i - 1] : null;
+        const older = i < adminList.length - 1 ? adminList[i + 1] : null;
+        const adminDisplay =
+            adminIndex.get(grant.data.administration_slug)?.displayName ??
+            grant.data.president_name;
+        return {
+            params: { slug: grant.data.slug },
+            props: {
+                grant,
+                adminDisplay,
+                newer: newer
+                    ? {
+                          slug: newer.data.slug,
+                          recipient_name: newer.data.recipient_name,
+                          grant_date: newer.data.grant_date,
+                      }
+                    : null,
+                older: older
+                    ? {
+                          slug: older.data.slug,
+                          recipient_name: older.data.recipient_name,
+                          grant_date: older.data.grant_date,
+                      }
+                    : null,
+            },
+        };
+    });
 }
 
-const { grant } = Astro.props;
+const { grant, adminDisplay, newer, older } = Astro.props;
 const data = grant.data;
 const currentPath = Astro.url.pathname;
 
-function formatDate(dateStr: string): string {
-    const [y, m, d] = dateStr.split("-");
-    return new Date(Number(y), Number(m) - 1, Number(d)).toLocaleDateString(
-        "en-US",
-        { year: "numeric", month: "long", day: "numeric" },
-    );
-}
-
-function formatDateShort(dateStr: string): string {
-    const [y, m, d] = dateStr.split("-");
-    return new Date(Number(y), Number(m) - 1, Number(d)).toLocaleDateString(
-        "en-US",
-        { year: "numeric", month: "short", day: "numeric" },
-    );
-}
-
-// Editorial convention: em-dash for null/zero (absence), currency for positive amounts
-function formatCurrency(amount: number | null): string {
-    if (amount === null || amount === undefined) return "—";
-    if (amount === 0) return "—";
-    return new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-        maximumFractionDigits: 0,
-    }).format(amount);
-}
-
-function formatSentence(months: number | null): string {
-    if (months === null || months === undefined) return "—";
-    if (months < 12) return `${months} months`;
-    const years = Math.floor(months / 12);
-    const remainingMonths = months % 12;
-    if (remainingMonths === 0) return `${years} year${years > 1 ? "s" : ""}`;
-    return `${years} year${years > 1 ? "s" : ""}, ${remainingMonths} month${remainingMonths > 1 ? "s" : ""}`;
-}
-
-function capitalize(s: string): string {
-    if (!s) return "";
-    return s.charAt(0).toUpperCase() + s.slice(1);
-}
+const grantDateLong = formatGrantDateLong(data.grant_date);
+const grantDateShort = formatGrantDateShort(data.grant_date);
 
 const clemencyLabels: Record<string, string> = {
     pardon: "Pardon",
     commutation: "Commutation",
 };
+const clemencyLabel =
+    clemencyLabels[data.clemency_type] ??
+    data.clemency_type.charAt(0).toUpperCase() + data.clemency_type.slice(1);
 
 const categoryLabels: Record<string, string> = {
     "violent crime": "Violent Crime",
@@ -75,308 +93,893 @@ const categoryLabels: Record<string, string> = {
     "financial crime": "Financial Crime",
     other: "Other",
 };
+const categoryLabel =
+    categoryLabels[data.offense_category] ??
+    data.offense_category.replace(/\b\w/g, (c) => c.toUpperCase());
 
-const grantDate = formatDate(data.grant_date);
-const grantDateShort = formatDateShort(data.grant_date);
-const formattedSentence = formatSentence(data.sentence_in_months);
-const formattedRestitution = formatCurrency(data.restitution);
-const formattedFine = formatCurrency(data.fine);
-
+// Offenses — split the comma-joined `offense` field into a numbered list
 const offenses = data.offense
     .split(",")
     .map((o) => o.trim())
     .filter((o) => o.length > 0);
 
-const hasRestitution = data.restitution != null && data.restitution > 0;
-
-type HeroStat = {
+// Money strip — up to 3 blocks. Hide each block when its source field is null.
+// The metadata grid below keeps the row-level em-dash convention; this strip
+// uses block-level absence (silent) per the bold spec.
+interface StripBlock {
     label: string;
     value: string;
-    footnote: string;
-    variant: "default" | "restitution";
-};
-let heroStat: HeroStat | null = null;
+    sub?: string;
+    accent: boolean;
+    muted: boolean;
+}
+const stripBlocks: StripBlock[] = [];
+
+const hasRestitution = data.restitution != null && data.restitution > 0;
+const hasFine = data.fine != null && data.fine > 0;
+const hasNumericSentence =
+    data.sentence_in_months != null && data.sentence_in_months > 0;
+const hasLifeSentence =
+    !hasNumericSentence && data.original_sentence?.toLowerCase().includes("life");
 
 if (hasRestitution) {
-    heroStat = {
-        label: "Restitution abandoned",
-        value: formattedRestitution,
-        footnote: "Originally ordered by the court",
-        variant: "restitution",
-    };
-} else if (data.sentence_in_months && data.sentence_in_months > 0) {
-    heroStat = {
+    stripBlocks.push({
+        label:
+            data.clemency_type === "commutation"
+                ? "Restitution at commutation"
+                : "Restitution forgiven",
+        value: formatCompactMoney(data.restitution),
+        sub: "Originally ordered by the court.",
+        accent: true,
+        muted: false,
+    });
+}
+if (hasFine) {
+    stripBlocks.push({
+        label:
+            data.clemency_type === "commutation"
+                ? "Fine at commutation"
+                : "Fine forgiven",
+        value: formatCompactMoney(data.fine),
+        sub: "Owed to the U.S. Treasury.",
+        accent: true,
+        muted: false,
+    });
+}
+if (hasNumericSentence) {
+    stripBlocks.push({
         label:
             data.clemency_type === "commutation"
                 ? "Sentence commuted"
-                : "Prison sentence",
-        value: formattedSentence,
-        footnote: `${data.sentence_in_months} months`,
-        variant: "default",
-    };
-} else if (data.original_sentence?.toLowerCase().includes("life")) {
-    heroStat = {
+                : "Sentence",
+        value: formatSentenceCompact(data.sentence_in_months),
+        sub: data.original_sentence ?? undefined,
+        accent: false,
+        muted: false,
+    });
+} else if (hasLifeSentence) {
+    stripBlocks.push({
         label:
             data.clemency_type === "commutation"
                 ? "Life sentence commuted"
                 : "Life sentence",
-        value: "Life imprisonment",
-        footnote: "Original sentence",
-        variant: "default",
-    };
+        value: "Life",
+        sub: data.original_sentence ?? undefined,
+        accent: false,
+        muted: false,
+    });
 }
 
-type MetaEntry = { label: string; value: string; emphasis?: boolean };
-
-// Group 1: Case details
-const caseDetails: MetaEntry[] = [
-    {
-        label: "Clemency Type",
-        value: clemencyLabels[data.clemency_type] ?? capitalize(data.clemency_type),
-    },
-    { label: "Grant Date", value: grantDate },
-    {
-        label: "Category",
-        value: categoryLabels[data.offense_category] ?? capitalize(data.offense_category),
-    },
-];
-
-if (data.district) {
-    caseDetails.push({ label: "District", value: data.district });
-}
-
-// Group 2: Sentencing & financial impact
-const sentencingDetails: MetaEntry[] = [];
-
-if (data.sentence_in_months != null) {
-    sentencingDetails.push({ label: "Sentence", value: formattedSentence });
-}
-
-// Restitution and fine always render — their absence is meaningful
-sentencingDetails.push({
-    label: "Restitution",
-    value: formattedRestitution,
-    emphasis: hasRestitution,
-});
-sentencingDetails.push({ label: "Fine", value: formattedFine });
-
+// Source documents (warrant + DOJ listing — both optional)
 const sources = [
     {
         url: resolveUrl(data.warrant_url),
-        icon: "📄",
-        title: "Pardon warrant (PDF)",
-        subtitle: "DOJ Office of the Pardon Attorney",
+        title: "Pardon warrant",
+        subtitle: "PDF · DOJ Office of the Pardon Attorney",
     },
     {
         url: resolveUrl(data.source_url),
-        icon: "🏛",
-        title: "DOJ clemency listing page",
+        title: "DOJ clemency listing",
         subtitle: "justice.gov/pardon",
     },
 ].filter((s) => s.url);
 
+// Aside metadata kv-rows — em-dash for null/undefined, "$0" preserved for zero
+type KvRow = { key: string; value: string; unknown?: boolean };
+const caseDetails: KvRow[] = [
+    { key: "Clemency type", value: clemencyLabel },
+    { key: "Granted", value: grantDateShort },
+    { key: "President", value: adminDisplay },
+    { key: "Category", value: categoryLabel },
+];
+if (data.district) {
+    caseDetails.push({ key: "District", value: data.district });
+} else {
+    caseDetails.push({ key: "District", value: "—", unknown: true });
+}
+
+const sentencingRows: KvRow[] = [];
+if (data.sentence_in_months != null) {
+    sentencingRows.push({
+        key: "Sentence",
+        value: formatSentenceMonths(data.sentence_in_months),
+    });
+} else {
+    sentencingRows.push({ key: "Sentence", value: "—", unknown: true });
+}
+sentencingRows.push({
+    key: "Restitution",
+    value: formatCurrencyPrecise(data.restitution),
+    unknown: data.restitution == null,
+});
+sentencingRows.push({
+    key: "Fine",
+    value: formatCurrencyPrecise(data.fine),
+    unknown: data.fine == null,
+});
+
+// SEO + OG
 const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     { name: "Home", url: "https://pardonned.com/" },
     { name: "Search", url: "https://pardonned.com/search" },
-    { name: data.recipient_name, url: `https://pardonned.com/pardon/details/${data.slug}` },
+    {
+        name: data.recipient_name,
+        url: `https://pardonned.com/pardon/details/${data.slug}`,
+    },
 ]);
 
 const ogDescriptionParts = [
-    `${clemencyLabels[data.clemency_type] ?? data.clemency_type} granted to ${data.recipient_name} on ${grantDate}.`,
+    `${clemencyLabel} granted to ${data.recipient_name} on ${grantDateLong}.`,
 ];
 if (hasRestitution) {
-    ogDescriptionParts.push(`${formattedRestitution} in restitution abandoned.`);
+    ogDescriptionParts.push(
+        `${formatCompactMoney(data.restitution)} in restitution abandoned.`,
+    );
 }
 const ogDescription = ogDescriptionParts.join(" ");
 const ogImagePath = `/og/${data.slug}.png`;
 ---
 
-<Layout title={data.recipient_name} description={ogDescription} ogImage={ogImagePath} currentPath={currentPath}>
-  <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
-    <div class="max-w-detail mx-auto px-5 md:px-10 py-6 md:py-10">
+<Layout
+    title={data.recipient_name}
+    description={ogDescription}
+    ogImage={ogImagePath}
+    currentPath={currentPath}
+>
+    <script type="application/ld+json" set:html={breadcrumbJsonLd}></script>
+
+    <main class="detail-bold">
         <!-- Breadcrumb -->
-        <div class="breadcrumb mb-6 md:mb-10">
-            <a
-                href="/search"
-                class="text-text-muted no-underline hover:text-text-primary transition-colors"
-                >Search</a
-            >
-            <span class="text-border-soft">/</span>
-            <span class="text-text-body">{data.recipient_name}</span>
+        <div class="db-crumb">
+            <a href="/search">Search</a>
+            <span class="db-crumb-sep">/</span>
+            <span class="db-crumb-here">{data.recipient_name}</span>
         </div>
 
-        <!-- Header: kicker + name + district -->
-        <div class="mb-10">
-            <div class="hero-tracking mb-4">
-                {clemencyLabels[data.clemency_type] ?? capitalize(data.clemency_type)} · {grantDateShort}
+        <!-- Editorial masthead -->
+        <header class="db-mast">
+            <div class="db-meta">
+                <span class="db-meta-pard">{clemencyLabel}</span>
+                <span class="db-meta-dot" aria-hidden="true">·</span>
+                <span class="db-meta-by">Granted by {adminDisplay}</span>
+                <span class="db-meta-dot" aria-hidden="true">·</span>
+                <span class="db-meta-by">{grantDateLong}</span>
             </div>
-            <h1
-                class="font-serif text-text-primary m-0 mb-3 text-[28px] md:text-detail-name"
-                style="letter-spacing: -0.02em;"
+            <h1 class="db-name">{data.recipient_name}.</h1>
+            {data.district && (
+                <p class="db-district">{data.district}</p>
+            )}
+        </header>
+
+        <!--
+            Money strip. Up to three <MoneyFigure> blocks (restitution, fine,
+            sentence). Each block is omitted when its source field is null.
+            Block-level absence is silent (per the bold spec); the row-level
+            metadata grid below uses em-dash semantics instead.
+        -->
+        {stripBlocks.length > 0 && (
+            <section
+                class="db-money-strip"
+                style={`grid-template-columns: repeat(${stripBlocks.length}, minmax(0, 1fr));`}
             >
-                {data.recipient_name}
-            </h1>
-            {
-                data.district && (
-                    <p class="text-body text-text-faint m-0">{data.district}</p>
-                )
-            }
-        </div>
+                {stripBlocks.map((block) => (
+                    <div class="db-mp">
+                        <div class="db-mp-lbl">{block.label}</div>
+                        <div
+                            class:list={[
+                                "db-mp-big",
+                                "font-serif",
+                                "tabular-nums",
+                                block.accent && "db-mp-accent",
+                                block.muted && "db-mp-muted",
+                            ]}
+                        >
+                            {block.value}
+                        </div>
+                        {block.sub && (
+                            <div class="db-mp-sub">{block.sub}</div>
+                        )}
+                    </div>
+                ))}
+            </section>
+        )}
 
-        <!-- Hero stat (conditional) -->
-        {
-            heroStat && (
-                <div class="mb-6 md:mb-10">
-                    <StatCard
-                        label={heroStat.label}
-                        value={heroStat.value}
-                        footnote={heroStat.footnote}
-                        variant={heroStat.variant}
-                    />
-                </div>
-            )
-        }
+        <!--
+            TODO (post AI-reclassification work): when the DB grows a
+            `warrant_text` column, render the pardon-warrant pull-quote here:
 
-        <!-- Offenses (lead content) -->
-        <div class="mb-6 md:mb-10">
-            <div class="overline">Offenses</div>
-            <ul class="list-none p-0 m-0 flex flex-col gap-3">
-                {
-                    offenses.map((offense) => (
-                        <li class="offense-item">
-                            <span
-                                class="text-text-primary"
-                                style="font-size: 16px; line-height: 1.5;"
-                            >
-                                {capitalize(offense)}
-                            </span>
-                        </li>
-                    ))
-                }
-            </ul>
-        </div>
+            <section class="db-pull-warrant">
+              <div class="db-pull-lbl">Pardon warrant text</div>
+              <p class="db-pull-text">{data.warrant_text}</p>
+              <div class="db-pull-src">Signed by {adminDisplay} · {grantDateLong}</div>
+            </section>
 
-        <!-- Original sentence (conditional, lead content) -->
-        {
-            data.original_sentence && (
-                <div class="mb-8 md:mb-12">
-                    <div class="overline">Original Sentence</div>
-                    <blockquote
-                        class="m-0 p-0 pl-5 text-text-body border-l-2 border-border"
-                        style="font-style: italic; font-size: 20px; line-height: 1.55;"
-                    >
-                        {data.original_sentence}
-                    </blockquote>
-                </div>
-            )
-        }
+            For now `warrant_text` does not exist on PardonDetail, so the
+            block is intentionally empty.
+        -->
 
-        <!-- Metadata groups -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12" data-animate>
-            <div class="metadata-group">
-                <div class="metadata-group-title">Case Details</div>
-                <div class="flex flex-col gap-4">
-                    {
-                        caseDetails.map((entry) => (
-                            <div>
-                                <div class="tracker-label mb-1">{entry.label}</div>
-                                <div class="text-body text-text-primary">
-                                    {entry.value}
+        <div class="db-grid">
+            <div class="db-main">
+                <!-- Offenses -->
+                <section class="db-section">
+                    <div class="db-section-eyebrow">The conviction</div>
+                    <h2 class="db-section-title">
+                        {offenses.length === 1
+                            ? "One federal count."
+                            : `${offenses.length} federal counts.`}
+                    </h2>
+                    <div class="db-off-list">
+                        {offenses.map((offense, i) => (
+                            <div class="db-off-row">
+                                <div class="db-off-n">
+                                    {String(i + 1).padStart(2, "0")}
+                                </div>
+                                <div class="db-off-text">
+                                    {offense.charAt(0).toUpperCase() +
+                                        offense.slice(1)}
                                 </div>
                             </div>
-                        ))
-                    }
-                </div>
+                        ))}
+                    </div>
+                </section>
+
+                <!-- Original sentence pull-quote (preserved bold-mockup treatment) -->
+                {data.original_sentence && (
+                    <section class="db-section">
+                        <div class="db-section-eyebrow">From the warrant</div>
+                        <h2 class="db-section-title">
+                            The original sentence.
+                        </h2>
+                        <div class="db-pull">
+                            <div class="db-pull-lbl">
+                                As recorded by the court
+                            </div>
+                            <p class="db-pull-text">{data.original_sentence}</p>
+                            {data.district && (
+                                <div class="db-pull-src">
+                                    {data.district} · DOJ warrant
+                                </div>
+                            )}
+                        </div>
+                    </section>
+                )}
             </div>
-            <div class="metadata-group">
-                <div class="metadata-group-title">Sentencing & Impact</div>
-                <div class="flex flex-col gap-4">
-                    {
-                        sentencingDetails.map((entry) => (
-                            <div>
-                                <div class="tracker-label mb-1">{entry.label}</div>
+
+            <aside class="db-aside">
+                <div class="db-aside-block">
+                    <h4>Case details</h4>
+                    <div class="db-kv">
+                        {caseDetails.map((row) => (
+                            <div class="db-kv-row">
+                                <div class="db-kv-k">{row.key}</div>
                                 <div
                                     class:list={[
-                                        "text-body",
-                                        entry.emphasis
-                                            ? "text-accent font-medium"
-                                            : "text-text-primary",
+                                        "db-kv-v",
+                                        row.unknown && "db-kv-unknown",
                                     ]}
                                 >
-                                    {entry.value}
+                                    {row.value}
                                 </div>
                             </div>
-                        ))
-                    }
+                        ))}
+                    </div>
                 </div>
-            </div>
-        </div>
 
-        <!-- Divider -->
-        <div class="divider-gradient mb-10" />
+                <div class="db-aside-block">
+                    <h4>Sentencing &amp; impact</h4>
+                    <div class="db-kv">
+                        {sentencingRows.map((row) => (
+                            <div class="db-kv-row">
+                                <div class="db-kv-k">{row.key}</div>
+                                <div
+                                    class:list={[
+                                        "db-kv-v",
+                                        row.unknown && "db-kv-unknown",
+                                    ]}
+                                >
+                                    {row.value}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
 
-        <!-- Source documents -->
-        <div data-animate>
-            <div class="overline">Source Documents</div>
-            <div class="flex flex-col gap-3">
-                {
-                    sources.length > 0 ? (
-                        sources.map((src) => (
+                {sources.length > 0 && (
+                    <div class="db-aside-block">
+                        <h4>Source documents</h4>
+                        {sources.map((src) => (
                             <a
                                 href={src.url}
                                 target="_blank"
                                 rel="noopener"
-                                class="source-link no-underline"
+                                class="db-doc-link"
                             >
-                                <span class="text-xl opacity-50">{src.icon}</span>
-                                <div>
-                                    <div class="text-nav text-text-primary mb-0.5">
-                                        {src.title}
-                                    </div>
-                                    <div class="text-meta text-text-faint">
-                                        {src.subtitle}
-                                    </div>
+                                <div class="db-doc-title">
+                                    {src.title}
+                                    <span class="db-doc-arrow">↗</span>
                                 </div>
-                                <span class="text-faint ml-auto source-link-arrow">↗</span>
+                                <div class="db-doc-sub">{src.subtitle}</div>
                             </a>
-                        ))
-                    ) : (
-                        <p class="text-body text-text-muted m-0">
-                            No source documents available.
-                        </p>
-                    )
-                }
-            </div>
+                        ))}
+                    </div>
+                )}
+            </aside>
         </div>
 
-        <!-- Bottom navigation -->
-        <div class="mt-12 pt-8 border-t border-border-DEFAULT flex justify-between items-center">
-            <a href="/search" class="load-more-btn inline-block no-underline">
-                ← Back to search
-            </a>
-        </div>
-    </div>
+        <!-- Footer cross-links: prev/next within administration + back -->
+        <nav class="db-footer-nav" aria-label="Pardon navigation">
+            <div class="db-footer-cell db-footer-prev">
+                {older ? (
+                    <a
+                        href={`/pardon/details/${older.slug}`}
+                        class="db-foot-link"
+                        data-direction="older"
+                    >
+                        <span class="db-foot-arrow" aria-hidden="true">←</span>
+                        <span class="db-foot-stack">
+                            <span class="db-foot-label">Previous</span>
+                            <span class="db-foot-name">
+                                {older.recipient_name}
+                            </span>
+                            <span class="db-foot-date">
+                                {formatGrantDateShort(older.grant_date)}
+                            </span>
+                        </span>
+                    </a>
+                ) : (
+                    <span class="db-foot-empty">—</span>
+                )}
+            </div>
+            <div class="db-footer-cell db-footer-back">
+                <a
+                    href={`/president/${data.administration_slug}`}
+                    class="db-back-link"
+                >
+                    Back to {adminDisplay}
+                </a>
+            </div>
+            <div class="db-footer-cell db-footer-next">
+                {newer ? (
+                    <a
+                        href={`/pardon/details/${newer.slug}`}
+                        class="db-foot-link db-foot-link-right"
+                        data-direction="newer"
+                    >
+                        <span class="db-foot-stack">
+                            <span class="db-foot-label">Next</span>
+                            <span class="db-foot-name">
+                                {newer.recipient_name}
+                            </span>
+                            <span class="db-foot-date">
+                                {formatGrantDateShort(newer.grant_date)}
+                            </span>
+                        </span>
+                        <span class="db-foot-arrow" aria-hidden="true">→</span>
+                    </a>
+                ) : (
+                    <span class="db-foot-empty">—</span>
+                )}
+            </div>
+        </nav>
+    </main>
 </Layout>
 
-<script src="/scripts/animate-on-scroll.js" is:inline></script>
-
-<script is:inline define:vars={{ recipientName: data.recipient_name, clemencyType: data.clemency_type, offenseCategory: data.offense_category }}>
-  document.addEventListener('DOMContentLoaded', () => {
-    // Track detail page view
-    window.posthog?.capture('pardon_detail_viewed', {
-      name: recipientName,
-      clemency_type: clemencyType,
-      offense_category: offenseCategory,
-    });
-
-    // Track source document clicks
-    document.querySelectorAll('a.source-link').forEach((link) => {
-      link.addEventListener('click', () => {
-        window.posthog?.capture('source_document_clicked', {
-          name: recipientName,
-          url: link.href,
+<script
+    is:inline
+    define:vars={{
+        recipientName: data.recipient_name,
+        clemencyType: data.clemency_type,
+        offenseCategory: data.offense_category,
+        grantSlug: data.slug,
+    }}
+>
+    document.addEventListener("DOMContentLoaded", () => {
+        // Track detail page view (PostHog continuity)
+        window.posthog?.capture("pardon_detail_viewed", {
+            name: recipientName,
+            clemency_type: clemencyType,
+            offense_category: offenseCategory,
+            slug: grantSlug,
         });
-      });
+
+        // Track source document clicks
+        document.querySelectorAll("a.db-doc-link").forEach((link) => {
+            link.addEventListener("click", () => {
+                window.posthog?.capture("source_document_clicked", {
+                    name: recipientName,
+                    url: link.href,
+                });
+            });
+        });
+
+        // Track prev/next navigation
+        document
+            .querySelectorAll("a.db-foot-link[data-direction]")
+            .forEach((link) => {
+                link.addEventListener("click", () => {
+                    window.posthog?.capture("pardon_neighbor_clicked", {
+                        from_slug: grantSlug,
+                        direction: link.getAttribute("data-direction"),
+                    });
+                });
+            });
     });
-  });
 </script>
+
+<style>
+    .detail-bold {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 0 40px;
+    }
+
+    /* Breadcrumb */
+    .db-crumb {
+        padding: 28px 0 0;
+        font-size: 12px;
+        color: var(--text-muted);
+        display: flex;
+        gap: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+    }
+    .db-crumb a {
+        color: var(--text-muted);
+        text-decoration: none;
+    }
+    .db-crumb a:hover {
+        color: var(--text-primary);
+    }
+    .db-crumb-sep {
+        color: var(--border-soft);
+    }
+    .db-crumb-here {
+        color: var(--text-body);
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    /* Editorial masthead */
+    .db-mast {
+        padding: 36px 0 56px;
+        border-bottom: var(--rule-emphasis);
+    }
+    .db-meta {
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
+        margin-bottom: 22px;
+        flex-wrap: wrap;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-weight: 500;
+    }
+    .db-meta-pard {
+        color: var(--accent);
+    }
+    .db-meta-by {
+        color: var(--text-faint);
+    }
+    .db-meta-dot {
+        color: var(--border-soft);
+    }
+    .db-name {
+        font-family: var(--serif);
+        font-size: 80px;
+        letter-spacing: -0.03em;
+        line-height: 0.95;
+        margin: 0 0 16px 0;
+        font-weight: 400;
+        color: var(--text-primary);
+    }
+    .db-district {
+        font-size: 18px;
+        color: var(--text-faint);
+        margin: 0;
+        line-height: 1.5;
+    }
+
+    /* Money strip */
+    .db-money-strip {
+        display: grid;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .db-mp {
+        padding: 36px 28px 36px 28px;
+        border-right: 1px solid var(--border-default);
+    }
+    .db-mp:first-child {
+        padding-left: 0;
+    }
+    .db-mp:last-child {
+        border-right: none;
+        padding-right: 0;
+    }
+    .db-mp-lbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--text-faint);
+        font-weight: 500;
+        margin-bottom: 14px;
+    }
+    .db-mp-big {
+        font-size: 56px;
+        letter-spacing: -0.025em;
+        line-height: 0.95;
+        margin-bottom: 8px;
+        color: var(--text-primary);
+    }
+    .db-mp-accent {
+        color: var(--accent);
+    }
+    .db-mp-muted {
+        color: var(--text-ghost);
+        font-size: 36px;
+    }
+    .db-mp-sub {
+        font-size: 12px;
+        color: var(--text-secondary);
+        line-height: 1.5;
+    }
+
+    /* Detail grid (main + aside) */
+    .db-grid {
+        display: grid;
+        grid-template-columns: 1fr 320px;
+        gap: 56px;
+        padding: 56px 0 60px;
+        align-items: start;
+    }
+    .db-main {
+        min-width: 0;
+    }
+
+    /* Section blocks in main column */
+    .db-section {
+        margin-bottom: 56px;
+    }
+    .db-section:last-child {
+        margin-bottom: 0;
+    }
+    .db-section-eyebrow {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: var(--accent);
+        font-weight: 500;
+        margin-bottom: 14px;
+    }
+    .db-section-title {
+        font-family: var(--serif);
+        font-size: 32px;
+        letter-spacing: -0.015em;
+        line-height: 1.1;
+        margin: 0 0 24px 0;
+        font-weight: 400;
+    }
+
+    /* Offenses list */
+    .db-off-list {
+        border-top: 1px solid var(--border-default);
+    }
+    .db-off-row {
+        display: grid;
+        grid-template-columns: 50px 1fr;
+        gap: 20px;
+        padding: 22px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: baseline;
+    }
+    .db-off-n {
+        font-family: var(--serif);
+        font-size: 28px;
+        color: var(--text-faint);
+        letter-spacing: -0.01em;
+        font-variant-numeric: tabular-nums;
+    }
+    .db-off-text {
+        font-size: 17px;
+        color: var(--text-primary);
+        line-height: 1.4;
+    }
+
+    /* Pull-quote */
+    .db-pull {
+        background: var(--accent-tint);
+        border-left: 3px solid var(--accent);
+        padding: 32px 36px;
+        margin: 0;
+    }
+    .db-pull-lbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: var(--accent);
+        margin-bottom: 16px;
+        font-weight: 500;
+    }
+    .db-pull-text {
+        font-family: var(--serif);
+        font-size: 22px;
+        line-height: 1.4;
+        color: var(--text-primary);
+        letter-spacing: -0.01em;
+        margin: 0;
+        font-style: italic;
+    }
+    .db-pull-src {
+        font-size: 12px;
+        color: var(--text-faint);
+        margin-top: 18px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+
+    /* Aside */
+    .db-aside {
+        min-width: 0;
+    }
+    .db-aside-block {
+        margin-bottom: 36px;
+        padding-bottom: 28px;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .db-aside-block:last-child {
+        border-bottom: none;
+    }
+    .db-aside-block h4 {
+        font-family: var(--sans);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: var(--text-faint);
+        font-weight: 500;
+        margin: 0 0 18px 0;
+    }
+    .db-kv {
+        display: flex;
+        flex-direction: column;
+    }
+    .db-kv-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: baseline;
+        font-size: 14px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .db-kv-row:last-child {
+        border-bottom: none;
+    }
+    .db-kv-k {
+        color: var(--text-faint);
+        font-size: 13px;
+    }
+    .db-kv-v {
+        color: var(--text-primary);
+        text-align: right;
+        font-weight: 500;
+        font-variant-numeric: tabular-nums;
+    }
+    .db-kv-unknown {
+        color: var(--text-ghost);
+        font-weight: 400;
+    }
+
+    /* Source document links */
+    .db-doc-link {
+        display: block;
+        padding: 16px 0;
+        border-bottom: 1px solid var(--border-default);
+        text-decoration: none;
+        color: var(--text-primary);
+        transition: padding 0.15s;
+    }
+    .db-doc-link:last-child {
+        border-bottom: none;
+    }
+    .db-doc-link:hover {
+        padding-left: 4px;
+    }
+    .db-doc-title {
+        font-size: 14px;
+        font-weight: 500;
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+    }
+    .db-doc-arrow {
+        color: var(--accent);
+        margin-left: auto;
+        font-size: 14px;
+    }
+    .db-doc-sub {
+        font-size: 12px;
+        color: var(--text-faint);
+        margin-top: 4px;
+    }
+
+    /* Footer cross-link strip */
+    .db-footer-nav {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 24px;
+        align-items: center;
+        border-top: 1px solid var(--border-default);
+        padding: 32px 0 60px;
+    }
+    .db-footer-cell {
+        min-width: 0;
+    }
+    .db-footer-prev {
+        text-align: left;
+    }
+    .db-footer-back {
+        text-align: center;
+    }
+    .db-footer-next {
+        text-align: right;
+    }
+    .db-foot-link {
+        display: inline-flex;
+        gap: 14px;
+        align-items: center;
+        text-decoration: none;
+        color: var(--text-primary);
+        max-width: 100%;
+    }
+    .db-foot-link-right {
+        flex-direction: row;
+    }
+    .db-foot-arrow {
+        font-size: 18px;
+        color: var(--accent);
+        flex-shrink: 0;
+    }
+    .db-foot-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+    }
+    .db-footer-prev .db-foot-stack {
+        align-items: flex-start;
+    }
+    .db-footer-next .db-foot-stack {
+        align-items: flex-end;
+    }
+    .db-foot-label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+    }
+    .db-foot-name {
+        font-family: var(--serif);
+        font-size: 17px;
+        line-height: 1.2;
+        max-width: 220px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .db-foot-date {
+        font-size: 12px;
+        color: var(--text-faint);
+        font-variant-numeric: tabular-nums;
+    }
+    .db-back-link {
+        font-size: 13px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: 500;
+        text-decoration: none;
+        border-bottom: 1px solid var(--border-default);
+        padding-bottom: 2px;
+    }
+    .db-back-link:hover {
+        color: var(--accent);
+        border-bottom-color: var(--accent-border);
+    }
+    .db-foot-empty {
+        color: var(--border-soft);
+        font-size: 18px;
+    }
+
+    /* Responsive */
+    @media (max-width: 900px) {
+        .detail-bold {
+            padding: 0 20px;
+        }
+        .db-name {
+            font-size: 44px;
+        }
+        .db-mast {
+            padding: 24px 0 36px;
+        }
+
+        .db-money-strip {
+            /* Force single-column on mobile regardless of inline grid-template-columns */
+            grid-template-columns: 1fr !important;
+        }
+        .db-mp {
+            padding: 24px 0;
+            border-right: none;
+            border-bottom: 1px solid var(--border-default);
+        }
+        .db-mp:last-child {
+            border-bottom: none;
+        }
+        .db-mp-big {
+            font-size: 40px;
+        }
+        .db-mp-muted {
+            font-size: 28px;
+        }
+
+        .db-grid {
+            grid-template-columns: 1fr;
+            gap: 36px;
+            padding: 36px 0 40px;
+        }
+
+        .db-section-title {
+            font-size: 26px;
+        }
+        .db-pull {
+            padding: 24px;
+        }
+        .db-pull-text {
+            font-size: 18px;
+        }
+
+        .db-footer-nav {
+            grid-template-columns: 1fr 1fr;
+            grid-template-areas:
+                "prev next"
+                "back back";
+            gap: 20px 16px;
+            padding: 24px 0 40px;
+        }
+        .db-footer-prev {
+            grid-area: prev;
+        }
+        .db-footer-next {
+            grid-area: next;
+        }
+        .db-footer-back {
+            grid-area: back;
+            text-align: center;
+        }
+        .db-foot-name {
+            max-width: 140px;
+            font-size: 14px;
+        }
+    }
+</style>

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -249,6 +249,7 @@ const timelineEntries = sortedDates.map((date, i) => {
                         href={`/president/${older.slug}`}
                         class="pp-foot-link"
                         data-direction="older"
+                        data-to-slug={older.slug}
                     >
                         <span class="pp-foot-arrow" aria-hidden="true">←</span>
                         <span class="pp-foot-stack">

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -10,17 +10,7 @@ import "../../styles/global.css";
 import { getCollection } from "astro:content";
 import { computeStats, filterByAdministration } from "../../lib/pardon-stats";
 import { getAdministrationIndex } from "../../lib/president-names";
-
-const categoryColors: Record<string, string> = {
-    fraud: "#8A6B1E",
-    "drug offense": "#3A6A4A",
-    firearms: "#C23B22",
-    "FACE act": "#B8652A",
-    "financial crime": "#2A6A7A",
-    "violent crime": "#6A4B7A",
-    immigration: "#7A6A3A",
-    other: "#7A7870",
-};
+import { getCategoryColor } from "../../lib/category-colors";
 
 export async function getStaticPaths() {
     const allGrants = await getCollection("pardonDetails");
@@ -46,7 +36,7 @@ const categoryCounts = Object.entries(stats.byCategory).map(([key, count]) => ({
     key,
     name: key.replace(/\b\w/g, (c) => c.toUpperCase()),
     count,
-    color: categoryColors[key] ?? "#7A7880",
+    color: getCategoryColor(key),
 }));
 
 const groupedByDate = entries.reduce(

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -273,6 +273,7 @@ const timelineEntries = sortedDates.map((date, i) => {
                         href={`/president/${newer.slug}`}
                         class="pp-foot-link pp-foot-link-right"
                         data-direction="newer"
+                        data-to-slug={newer.slug}
                     >
                         <span class="pp-foot-stack">
                             <span class="pp-foot-label">Next administration</span>
@@ -322,6 +323,7 @@ const timelineEntries = sortedDates.map((date, i) => {
                 link.addEventListener("click", () => {
                     window.posthog?.capture("administration_neighbor_clicked", {
                         from_slug: adminSlug,
+                        to_slug: link.getAttribute("data-to-slug"),
                         direction: link.getAttribute("data-direction"),
                     });
                 });

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -1,16 +1,15 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import StatGrid from "../../components/StatGrid.astro";
-import CategoryGrid from "../../components/CategoryGrid.astro";
+import MoneyFigure from "../../components/MoneyFigure.astro";
 import Timeline from "../../components/Timeline.astro";
 import SourceBanner from "../../components/SourceBanner.astro";
-import FilterPill from "../../components/FilterPill.astro";
 import "../../styles/global.css";
 
 import { getCollection } from "astro:content";
 import { computeStats, filterByAdministration } from "../../lib/pardon-stats";
 import { getAdministrationIndex } from "../../lib/president-names";
 import { getCategoryColor } from "../../lib/category-colors";
+import { formatCompactMoney, formatGrantDateLong } from "../../lib/format";
 
 export async function getStaticPaths() {
     const allGrants = await getCollection("pardonDetails");
@@ -19,26 +18,76 @@ export async function getStaticPaths() {
         b.termStartDate.localeCompare(a.termStartDate),
     );
 
-    return sortedAdmins.map((admin) => ({
-        params: { slug: admin.slug },
-        props: {
-            admin,
-            entries: filterByAdministration(allGrants, admin.slug),
-            allAdmins: sortedAdmins,
-        },
-    }));
+    return sortedAdmins.map((admin, i) => {
+        const entries = filterByAdministration(allGrants, admin.slug);
+        // term_end_date isn't on the admin index; derive from any entry.
+        // For incumbents the field is null and we render an open-ended range.
+        const termEndDate = entries[0]?.data.term_end_date ?? null;
+
+        // Chronological neighbours. sortedAdmins is desc by termStartDate, so
+        //   newer = sortedAdmins[i - 1]   (later in time)
+        //   older = sortedAdmins[i + 1]   (earlier in time)
+        // We label them "Next" / "Previous" by chronology.
+        const newer = i > 0 ? sortedAdmins[i - 1] : null;
+        const older = i < sortedAdmins.length - 1 ? sortedAdmins[i + 1] : null;
+
+        return {
+            params: { slug: admin.slug },
+            props: {
+                admin,
+                entries,
+                termEndDate,
+                newer: newer
+                    ? { slug: newer.slug, displayName: newer.displayName, termStartDate: newer.termStartDate }
+                    : null,
+                older: older
+                    ? { slug: older.slug, displayName: older.displayName, termStartDate: older.termStartDate }
+                    : null,
+            },
+        };
+    });
 }
 
-const { admin, entries, allAdmins } = Astro.props;
+const { admin, entries, termEndDate, newer, older } = Astro.props;
 const stats = computeStats(entries);
 
-const categoryCounts = Object.entries(stats.byCategory).map(([key, count]) => ({
-    key,
-    name: key.replace(/\b\w/g, (c) => c.toUpperCase()),
-    count,
-    color: getCategoryColor(key),
-}));
+// Category breakdown — sorted desc, with proportional bars
+const categoryRows = Object.entries(stats.byCategory)
+    .map(([key, count]) => ({
+        key,
+        name: key.replace(/\b\w/g, (c) => c.toUpperCase()),
+        count,
+        color: getCategoryColor(key),
+    }))
+    .sort((a, b) => b.count - a.count);
+const maxCategoryCount = Math.max(1, ...categoryRows.map((r) => r.count));
 
+// Term subtitle: "Second Term · 2025–" / "First Term · 2021–2025" / single-term: "2017–2021"
+const termOrdinals: Record<number, string> = {
+    1: "First Term",
+    2: "Second Term",
+    3: "Third Term",
+    4: "Fourth Term",
+};
+const termStartYear = admin.termStartDate.slice(0, 4);
+const termEndYear = termEndDate ? termEndDate.slice(0, 4) : "";
+const yearRange = termEndYear ? `${termStartYear}–${termEndYear}` : `${termStartYear}–`;
+const isOnlyTerm = !admin.displayName.includes("Term");
+const termSubtitle = isOnlyTerm
+    ? yearRange
+    : `${termOrdinals[admin.termNumber] ?? `Term ${admin.termNumber}`} · ${yearRange}`;
+
+// Bare president name (drop the "(Second Term)" suffix for the masthead h1)
+const presidentName = admin.displayName.replace(/\s*\([^)]+\)\s*$/, "");
+
+// Data-driven J6 footnote. Auto-disappears once January-6 records land in the
+// data with `offense_category === "january 6"` (separate AI-reclassification
+// effort). Only rendered for Trump administrations.
+const j6Count = stats.byCategory["january 6"] ?? 0;
+const showJ6Footnote = admin.slug.startsWith("trump-") && j6Count === 0;
+
+// Build Timeline entries (preserved from prior implementation — same shape
+// the existing Timeline component expects, only the visual treatment differs)
 const groupedByDate = entries.reduce(
     (acc, entry) => {
         const date = entry.data.grant_date;
@@ -48,61 +97,34 @@ const groupedByDate = entries.reduce(
     },
     {} as Record<string, (typeof entries)[number]["data"][]>,
 );
-
-const sortedDates = Object.keys(groupedByDate).sort((a, b) =>
-    b.localeCompare(a),
-);
+const sortedDates = Object.keys(groupedByDate).sort((a, b) => b.localeCompare(a));
 
 const timelineEntries = sortedDates.map((date, i) => {
     const grants = groupedByDate[date];
     const names = grants.map((g) => g.recipient_name);
     const categories = [...new Set(grants.map((g) => g.offense_category))];
     const pardons = grants.filter((g) => g.clemency_type === "pardon").length;
-    const commutations = grants.filter(
-        (g) => g.clemency_type === "commutation",
-    ).length;
-
+    const commutations = grants.filter((g) => g.clemency_type === "commutation").length;
     const hrefs = grants.reduce(
         (acc, grant) => {
-            acc[grant.recipient_name] =
-                `/pardon/details/${grant.slug}`;
+            acc[grant.recipient_name] = `/pardon/details/${grant.slug}`;
             return acc;
         },
         {} as Record<string, string>,
     );
-
     const parts: string[] = [];
-    if (pardons > 0)
-        parts.push(`${pardons} ${pardons === 1 ? "pardon" : "pardons"}`);
+    if (pardons > 0) parts.push(`${pardons} ${pardons === 1 ? "pardon" : "pardons"}`);
     if (commutations > 0)
-        parts.push(
-            `${commutations} ${commutations === 1 ? "commutation" : "commutations"}`,
-        );
-
-    const grantLabel = parts.join(", ");
-    const [y, m, d] = date.split("-");
-    const formattedDate = new Date(
-        Number(y),
-        Number(m) - 1,
-        Number(d),
-    ).toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-    });
-
+        parts.push(`${commutations} ${commutations === 1 ? "commutation" : "commutations"}`);
     return {
-        date: formattedDate,
-        grants: grantLabel,
+        date: formatGrantDateLong(date),
+        grants: parts.join(", "),
         names,
         highlight: categories.join(", "),
         isLatest: i === 0,
         hrefs,
     };
 });
-
-const isTrump = admin.slug.startsWith("trump-");
-const footnote = isTrump ? "Does not include January 6th" : undefined;
 ---
 
 <Layout
@@ -111,94 +133,597 @@ const footnote = isTrump ? "Does not include January 6th" : undefined;
     ogImage={`/og/president/${admin.slug}.png`}
     currentPath={`/president/${admin.slug}`}
 >
-    <!-- President Navigation Pills -->
-    <nav class="max-w-home mx-auto px-5 md:px-10 pt-8 pb-2">
-        <div class="flex flex-wrap gap-2">
-            <FilterPill label="All" href="/" />
-            {allAdmins.map((a) => (
-                <FilterPill
-                    label={a.displayName}
-                    count={a.count}
-                    href={`/president/${a.slug}`}
-                    active={a.slug === admin.slug}
-                />
-            ))}
+    <main class="president-page-bold">
+        <!-- Breadcrumb -->
+        <div class="pp-crumb">
+            <a href="/">Home</a>
+            <span class="pp-crumb-sep">/</span>
+            <a href="/all-presidents">Presidents</a>
+            <span class="pp-crumb-sep">/</span>
+            <span class="pp-crumb-here">{presidentName}</span>
         </div>
-    </nav>
 
-    <!-- Hero Section -->
-    <section class="py-10 md:py-20 px-5 md:px-10 max-w-home mx-auto text-center">
-        <h1 class="hero-headline mb-6 max-w-3xl mx-auto">
-            Pardons granted by {admin.displayName}
-        </h1>
-        {isTrump && (
-            <h2 class="hero-subtitle mb-8">Not Including the January 6th Pardons</h2>
-        )}
-        <StatGrid stats={stats} animated={true} footnote={footnote} />
-    </section>
+        <!-- Editorial masthead -->
+        <header class="pp-mast">
+            <div class="pp-mast-kicker">Clemency record</div>
+            <h1 class="pp-mast-name">
+                {presidentName}.
+                <span class="pp-mast-term">{termSubtitle}</span>
+            </h1>
+            {showJ6Footnote && (
+                <p class="pp-mast-footnote">
+                    Counts below do not include January 6 defendants — pending classification in the dataset.
+                </p>
+            )}
+        </header>
 
-    <!-- Gradient Divider -->
-    <div class="max-w-home mx-auto px-5 md:px-10">
-        <div class="divider-gradient"></div>
-    </div>
+        <!-- 4-stat number wall -->
+        <section class="pp-numwall">
+            <div class="pp-nw">
+                <div class="pp-nw-lbl">Grants</div>
+                <div class="pp-nw-big">{stats.totalGrants.toLocaleString()}</div>
+                <div class="pp-nw-sub">Pardons and commutations issued during this term.</div>
+            </div>
+            <div class="pp-nw">
+                <div class="pp-nw-lbl">Pardons</div>
+                <div class="pp-nw-big">{stats.totalPardons.toLocaleString()}</div>
+                <div class="pp-nw-sub">
+                    {stats.totalGrants > 0
+                        ? `${Math.round((stats.totalPardons / stats.totalGrants) * 100)}% of grants.`
+                        : "—"}
+                </div>
+            </div>
+            <div class="pp-nw">
+                <div class="pp-nw-lbl">Commutations</div>
+                <div class="pp-nw-big">{stats.totalCommutations.toLocaleString()}</div>
+                <div class="pp-nw-sub">
+                    {stats.totalGrants > 0
+                        ? `${Math.round((stats.totalCommutations / stats.totalGrants) * 100)}% of grants.`
+                        : "—"}
+                </div>
+            </div>
+            <div class="pp-nw">
+                <div class="pp-nw-lbl">Restitution forgiven</div>
+                <div class="pp-nw-big pp-nw-accent">
+                    {formatCompactMoney(stats.totalRestitutionAbandoned)}
+                </div>
+                <div class="pp-nw-sub">
+                    Money owed to victims that recipients no longer have to pay back.
+                </div>
+            </div>
+        </section>
 
-    <!-- Categories Section -->
-    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
-        <h2 class="text-section font-serif text-text-primary mb-2">
-            By Offense Category
-        </h2>
-        <p class="text-nav text-text-faint mb-10">
-            Breakdown of all pardons by type of offense
-        </p>
-        <CategoryGrid
-            categoryCounts={categoryCounts}
-            columns={3}
-            hrefPattern={`/search?president=${admin.slug}&category={key}`}
-        />
-    </section>
+        <!-- Composition + Timeline split layout -->
+        <section class="pp-split">
+            <div>
+                <h2 class="pp-section-title">Composition.</h2>
+                <p class="pp-section-deck">
+                    Where this term's grants concentrate, by offense category.
+                </p>
+                <div class="pp-cat-list">
+                    {categoryRows.map((row) => {
+                        const pct = (row.count / maxCategoryCount) * 100;
+                        return (
+                            <a
+                                class="pp-cat-row"
+                                href={`/search?president=${admin.slug}&category=${encodeURIComponent(row.key)}`}
+                                data-category={row.key}
+                            >
+                                <div class="pp-cat-nm">
+                                    <span class="pp-cat-dot" style={`background:${row.color};`} aria-hidden="true"></span>
+                                    <span class="pp-cat-name">{row.name}</span>
+                                </div>
+                                <div class="pp-cat-bar">
+                                    <div class="pp-cat-fill" style={`width:${pct}%; background:${row.color};`}></div>
+                                </div>
+                                <div class="pp-cat-ct">{row.count.toLocaleString()}</div>
+                            </a>
+                        );
+                    })}
+                </div>
+            </div>
+            <div>
+                <h2 class="pp-section-title">Timeline.</h2>
+                <p class="pp-section-deck">
+                    Every clemency action in reverse chronological order.
+                </p>
+                <Timeline entries={timelineEntries} />
 
-    <!-- Flat Divider -->
-    <div class="max-w-home mx-auto px-5 md:px-10">
-        <div class="divider-flat"></div>
-    </div>
+                <div class="pp-timeline-cta">
+                    <a
+                        href={`/search?president=${admin.slug}`}
+                        class="pp-timeline-cta-link"
+                        data-search-cta
+                    >
+                        View all {stats.totalGrants.toLocaleString()} grants from this term →
+                    </a>
+                </div>
+            </div>
+        </section>
 
-    <!-- Timeline Section -->
-    <section class="py-10 md:py-section px-5 md:px-10 max-w-home mx-auto" data-animate>
-        <h2 class="text-section font-serif text-text-primary mb-2">Timeline</h2>
-        <p class="text-nav text-text-faint mb-10">
-            Every clemency action in reverse chronological order
-        </p>
-        <Timeline entries={timelineEntries} />
+        <!-- Footer cross-link strip: chronological prev/next + view-all -->
+        <nav class="pp-footer-nav" aria-label="Administration navigation">
+            <div class="pp-footer-cell pp-footer-prev">
+                {older ? (
+                    <a
+                        href={`/president/${older.slug}`}
+                        class="pp-foot-link"
+                        data-direction="older"
+                    >
+                        <span class="pp-foot-arrow" aria-hidden="true">←</span>
+                        <span class="pp-foot-stack">
+                            <span class="pp-foot-label">Previous administration</span>
+                            <span class="pp-foot-name">{older.displayName}</span>
+                            <span class="pp-foot-year">{older.termStartDate.slice(0, 4)}</span>
+                        </span>
+                    </a>
+                ) : (
+                    <span class="pp-foot-empty">—</span>
+                )}
+            </div>
+            <div class="pp-footer-cell pp-footer-back">
+                <a href="/all-presidents" class="pp-back-link">
+                    View all administrations →
+                </a>
+            </div>
+            <div class="pp-footer-cell pp-footer-next">
+                {newer ? (
+                    <a
+                        href={`/president/${newer.slug}`}
+                        class="pp-foot-link pp-foot-link-right"
+                        data-direction="newer"
+                    >
+                        <span class="pp-foot-stack">
+                            <span class="pp-foot-label">Next administration</span>
+                            <span class="pp-foot-name">{newer.displayName}</span>
+                            <span class="pp-foot-year">{newer.termStartDate.slice(0, 4)}</span>
+                        </span>
+                        <span class="pp-foot-arrow" aria-hidden="true">→</span>
+                    </a>
+                ) : (
+                    <span class="pp-foot-empty">—</span>
+                )}
+            </div>
+        </nav>
 
-        <div class="text-center mt-5">
-            <a href={`/search?president=${admin.slug}`} class="load-more-btn inline-block no-underline">
-                Search all pardons →
-            </a>
-        </div>
-    </section>
-
-    <!-- Source Banner -->
-    <section class="max-w-source mx-auto px-5 md:px-8 mb-10">
-        <SourceBanner />
-    </section>
+        <!-- Source attribution -->
+        <section class="pp-source-band">
+            <SourceBanner />
+        </section>
+    </main>
 </Layout>
 
 <script src="/scripts/animate-on-scroll.js" is:inline></script>
 
-<script is:inline>
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelector('.grid')?.addEventListener('click', (e) => {
-      const card = e.target.closest('a[href*="category="]');
-      if (!card) return;
-      const url = new URL(card.href, window.location.origin);
-      const category = url.searchParams.get('category');
-      if (category) {
-        window.posthog?.capture('category_clicked', { category, source: 'president_page' });
-      }
-    });
+<script is:inline define:vars={{ adminSlug: admin.slug }}>
+    document.addEventListener("DOMContentLoaded", () => {
+        // category_clicked — preserved from the prior implementation
+        document.querySelectorAll("a.pp-cat-row[data-category]").forEach((row) => {
+            row.addEventListener("click", () => {
+                window.posthog?.capture("category_clicked", {
+                    category: row.getAttribute("data-category"),
+                    source: "president_page",
+                });
+            });
+        });
 
-    document.querySelector('a[href*="/search"].load-more-btn')?.addEventListener('click', () => {
-      window.posthog?.capture('search_all_pardons_clicked', { source: 'president_page' });
+        // search_all_pardons_clicked — preserved
+        document.querySelector("a[data-search-cta]")?.addEventListener("click", () => {
+            window.posthog?.capture("search_all_pardons_clicked", {
+                source: "president_page",
+            });
+        });
+
+        // administration_neighbor_clicked — new, for the chronological prev/next strip
+        document
+            .querySelectorAll("a.pp-foot-link[data-direction]")
+            .forEach((link) => {
+                link.addEventListener("click", () => {
+                    window.posthog?.capture("administration_neighbor_clicked", {
+                        from_slug: adminSlug,
+                        direction: link.getAttribute("data-direction"),
+                    });
+                });
+            });
     });
-  });
 </script>
+
+<style is:global>
+    .president-page-bold {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 0 40px;
+    }
+
+    /* Breadcrumb */
+    .pp-crumb {
+        padding: 28px 0 0;
+        font-size: 12px;
+        color: var(--text-muted);
+        display: flex;
+        gap: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+    }
+    .pp-crumb a {
+        color: var(--text-muted);
+        text-decoration: none;
+    }
+    .pp-crumb a:hover {
+        color: var(--text-primary);
+    }
+    .pp-crumb-sep {
+        color: var(--border-soft);
+    }
+    .pp-crumb-here {
+        color: var(--text-body);
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    /* Editorial masthead */
+    .pp-mast {
+        padding: 32px 0 56px;
+        border-bottom: var(--rule-emphasis);
+    }
+    .pp-mast-kicker {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: var(--accent);
+        margin-bottom: 24px;
+        font-weight: 500;
+    }
+    .pp-mast-name {
+        font-family: var(--serif);
+        font-size: 84px;
+        letter-spacing: -0.03em;
+        line-height: 0.95;
+        margin: 0;
+        font-weight: 400;
+        color: var(--text-primary);
+    }
+    .pp-mast-term {
+        display: block;
+        font-size: 32px;
+        color: var(--text-faint);
+        letter-spacing: -0.01em;
+        margin-top: 14px;
+        font-variant-numeric: tabular-nums;
+    }
+    .pp-mast-footnote {
+        font-size: 13px;
+        color: var(--text-faint);
+        font-style: italic;
+        margin: 24px 0 0 0;
+        line-height: 1.55;
+        max-width: 720px;
+    }
+
+    /* 4-stat number wall */
+    .pp-numwall {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        border-bottom: 1px solid var(--border-default);
+    }
+    .pp-nw {
+        padding: 36px 28px;
+        border-right: 1px solid var(--border-default);
+    }
+    .pp-nw:first-child {
+        padding-left: 0;
+    }
+    .pp-nw:last-child {
+        padding-right: 0;
+        border-right: none;
+    }
+    .pp-nw-lbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--text-faint);
+        font-weight: 500;
+        margin-bottom: 12px;
+    }
+    .pp-nw-big {
+        font-family: var(--serif);
+        font-size: 64px;
+        line-height: 0.95;
+        letter-spacing: -0.025em;
+        margin-bottom: 8px;
+        font-variant-numeric: tabular-nums;
+        color: var(--text-primary);
+    }
+    .pp-nw-accent {
+        color: var(--accent);
+    }
+    .pp-nw-sub {
+        font-size: 12px;
+        color: var(--text-secondary);
+        line-height: 1.5;
+    }
+
+    /* Composition + Timeline split */
+    .pp-split {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 64px;
+        padding: 64px 0;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .pp-section-title {
+        font-family: var(--serif);
+        font-size: 32px;
+        letter-spacing: -0.015em;
+        line-height: 1.1;
+        margin: 0 0 8px 0;
+        font-weight: 400;
+    }
+    .pp-section-deck {
+        font-size: 13px;
+        color: var(--text-secondary);
+        margin: 0 0 28px 0;
+        line-height: 1.55;
+    }
+
+    /* Category breakdown — proportional bar list */
+    .pp-cat-list {
+        display: flex;
+        flex-direction: column;
+    }
+    .pp-cat-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr 60px;
+        gap: 16px;
+        padding: 14px 0;
+        border-bottom: 1px solid var(--border-default);
+        align-items: center;
+        text-decoration: none;
+        color: inherit;
+        font-size: 14px;
+        transition: background 0.15s;
+    }
+    .pp-cat-row:last-child {
+        border-bottom: none;
+    }
+    .pp-cat-row:hover {
+        background: var(--bg-muted);
+    }
+    .pp-cat-nm {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    .pp-cat-dot {
+        width: 10px;
+        height: 10px;
+        flex-shrink: 0;
+    }
+    .pp-cat-name {
+        color: var(--text-body);
+        text-transform: capitalize;
+    }
+    .pp-cat-bar {
+        height: 6px;
+        background: var(--bg-muted);
+        position: relative;
+        overflow: hidden;
+    }
+    .pp-cat-fill {
+        height: 100%;
+    }
+    .pp-cat-ct {
+        font-family: var(--serif);
+        font-size: 18px;
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+        letter-spacing: -0.01em;
+    }
+
+    /* Timeline component bold restyle (overrides global Timeline classes
+       for elements rendered inside this page only) */
+    .president-page-bold .timeline-container {
+        padding-left: 16px;
+    }
+    .president-page-bold .timeline-line {
+        background: var(--border-default);
+    }
+    .president-page-bold .timeline-date {
+        font-family: var(--serif);
+        font-size: 18px;
+        letter-spacing: -0.01em;
+        color: var(--text-primary);
+        font-weight: 400;
+        font-variant-numeric: tabular-nums;
+    }
+    .president-page-bold .timeline-grants-badge {
+        background: transparent;
+        border: 1px solid var(--accent-border);
+        color: var(--accent);
+        border-radius: 2px;
+    }
+    .president-page-bold .timeline-highlight {
+        font-family: var(--sans);
+        font-size: 12px;
+        color: var(--text-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-style: normal;
+    }
+    .president-page-bold .timeline-dot {
+        border-radius: 0;
+        width: 10px;
+        height: 10px;
+    }
+
+    /* Timeline CTA */
+    .pp-timeline-cta {
+        margin-top: 28px;
+    }
+    .pp-timeline-cta-link {
+        font-size: 13px;
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-border);
+        padding-bottom: 1px;
+        text-decoration: none;
+    }
+    .pp-timeline-cta-link:hover {
+        border-bottom-color: var(--accent);
+    }
+
+    /* Footer cross-link strip */
+    .pp-footer-nav {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 24px;
+        align-items: center;
+        padding: 32px 0 56px;
+    }
+    .pp-footer-cell {
+        min-width: 0;
+    }
+    .pp-footer-prev {
+        text-align: left;
+    }
+    .pp-footer-back {
+        text-align: center;
+    }
+    .pp-footer-next {
+        text-align: right;
+    }
+    .pp-foot-link {
+        display: inline-flex;
+        gap: 14px;
+        align-items: center;
+        text-decoration: none;
+        color: var(--text-primary);
+        max-width: 100%;
+    }
+    .pp-foot-arrow {
+        font-size: 18px;
+        color: var(--accent);
+        flex-shrink: 0;
+    }
+    .pp-foot-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+    }
+    .pp-footer-prev .pp-foot-stack {
+        align-items: flex-start;
+    }
+    .pp-footer-next .pp-foot-stack {
+        align-items: flex-end;
+    }
+    .pp-foot-label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+    }
+    .pp-foot-name {
+        font-family: var(--serif);
+        font-size: 18px;
+        line-height: 1.2;
+        max-width: 220px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .pp-foot-year {
+        font-size: 12px;
+        color: var(--text-faint);
+        font-variant-numeric: tabular-nums;
+    }
+    .pp-back-link {
+        font-size: 13px;
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-border);
+        padding-bottom: 2px;
+        text-decoration: none;
+    }
+    .pp-back-link:hover {
+        border-bottom-color: var(--accent);
+    }
+    .pp-foot-empty {
+        color: var(--border-soft);
+        font-size: 18px;
+    }
+
+    /* Source attribution */
+    .pp-source-band {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 0 0 60px;
+    }
+
+    /* Responsive */
+    @media (max-width: 900px) {
+        .president-page-bold {
+            padding: 0 20px;
+        }
+        .pp-mast-name {
+            font-size: 48px;
+        }
+        .pp-mast-term {
+            font-size: 22px;
+        }
+        .pp-numwall {
+            grid-template-columns: 1fr 1fr;
+        }
+        .pp-nw {
+            padding: 28px 16px;
+            border-right: none;
+        }
+        .pp-nw:nth-child(odd) {
+            padding-left: 0;
+        }
+        .pp-nw:nth-child(even) {
+            padding-right: 0;
+        }
+        .pp-nw:nth-child(1),
+        .pp-nw:nth-child(2) {
+            border-bottom: 1px solid var(--border-default);
+        }
+        .pp-nw:nth-child(odd) {
+            border-right: 1px solid var(--border-default);
+        }
+        .pp-nw-big {
+            font-size: 44px;
+        }
+
+        .pp-split {
+            grid-template-columns: 1fr;
+            gap: 48px;
+            padding: 48px 0;
+        }
+        .pp-section-title {
+            font-size: 26px;
+        }
+
+        .pp-footer-nav {
+            grid-template-columns: 1fr 1fr;
+            grid-template-areas:
+                "prev next"
+                "back back";
+            gap: 20px 16px;
+            padding: 24px 0 40px;
+        }
+        .pp-footer-prev {
+            grid-area: prev;
+        }
+        .pp-footer-next {
+            grid-area: next;
+        }
+        .pp-footer-back {
+            grid-area: back;
+        }
+        .pp-foot-name {
+            max-width: 140px;
+            font-size: 14px;
+        }
+    }
+</style>

--- a/src/pages/recent.astro
+++ b/src/pages/recent.astro
@@ -117,7 +117,7 @@ function dayLabel(isoDate: string): string {
                 )}
             </div>
             <h1 class="rb-headline">
-                <span class="rb-quiet">Clemency by</span><br />
+                <span class="rb-quiet">Pardons by</span><br />
                 {currentAdmin?.displayName ?? "the current administration"}.
             </h1>
             <p class="rb-deck">

--- a/src/pages/recent.astro
+++ b/src/pages/recent.astro
@@ -1,0 +1,786 @@
+---
+import Layout from "../layouts/Layout.astro";
+import "../styles/global.css";
+
+import { getCollection } from "astro:content";
+import {
+    getAdministrationIndex,
+    getCurrentAdministration,
+} from "../lib/president-names";
+import { getCategoryColor } from "../lib/category-colors";
+import {
+    formatCompactMoney,
+    formatGrantDateLong,
+} from "../lib/format";
+
+const currentPath = Astro.url.pathname;
+
+const allGrants = await getCollection("pardonDetails");
+const adminIndex = getAdministrationIndex(allGrants);
+
+// Scope: this feed is the *current* administration's clemency record only.
+// Earlier administrations live in /search. Data-driven via term_start_date —
+// when the next administration's grants land, this rotates automatically.
+const currentAdmin = getCurrentAdministration(allGrants);
+const currentAdminGrants = currentAdmin
+    ? allGrants.filter(
+          (e) => e.data.administration_slug === currentAdmin.slug,
+      )
+    : [];
+
+const sortedGrants = currentAdminGrants
+    .slice()
+    .sort((a, b) => b.data.grant_date.localeCompare(a.data.grant_date));
+
+const termStartYear = currentAdmin?.termStartDate.slice(0, 4) ?? "";
+const termEndYear = sortedGrants[0]?.data.term_end_date?.slice(0, 4) ?? "";
+const termRange = termEndYear
+    ? `${termStartYear}–${termEndYear}`
+    : `${termStartYear}–`;
+
+interface MonthGroup {
+    key: string; // "2025-12"
+    label: string; // "December 2025"
+    entries: typeof sortedGrants;
+    pardons: number;
+    commutations: number;
+    restitution: number;
+}
+
+const months: MonthGroup[] = [];
+const monthIndex = new Map<string, MonthGroup>();
+for (const entry of sortedGrants) {
+    const key = entry.data.grant_date.slice(0, 7);
+    let group = monthIndex.get(key);
+    if (!group) {
+        const [yyyy, mm] = key.split("-");
+        const label = new Date(
+            Number(yyyy),
+            Number(mm) - 1,
+            1,
+        ).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+        group = {
+            key,
+            label,
+            entries: [],
+            pardons: 0,
+            commutations: 0,
+            restitution: 0,
+        };
+        monthIndex.set(key, group);
+        months.push(group);
+    }
+    group.entries.push(entry);
+    if (entry.data.clemency_type === "pardon") group.pardons++;
+    else group.commutations++;
+    if (entry.data.restitution != null) group.restitution += entry.data.restitution;
+}
+
+// Initial reveal cap — first N months render visible, rest hidden until the
+// "Load older" button reveals them. Per the issue spec.
+const INITIAL_VISIBLE_MONTHS = 2;
+
+const lastUpdatedDate = sortedGrants[0]?.data.grant_date;
+const lastUpdatedFormatted = lastUpdatedDate
+    ? formatGrantDateLong(lastUpdatedDate)
+    : null;
+
+function dayLabel(isoDate: string): string {
+    const [, , dd] = isoDate.split("-");
+    return String(Number(dd));
+}
+---
+
+<Layout
+    title="Recent grants"
+    description="A chronological feed of federal pardons and commutations, newest first. Each entry links to the original DOJ warrant."
+    ogImage="/og/recent.png"
+    currentPath={currentPath}
+>
+    <main class="recent-bold">
+        <div class="rb-crumb">
+            <a href="/">Home</a>
+            <span class="rb-crumb-sep">/</span>
+            <span class="rb-crumb-here">Recent</span>
+        </div>
+
+        <header class="rb-mast">
+            <div class="rb-mast-top">
+                <span class="rb-stamp">
+                    <span class="rb-stamp-dot" aria-hidden="true"></span>
+                    Live feed · {termRange}
+                </span>
+                {lastUpdatedFormatted && (
+                    <span class="rb-updated">
+                        Last grant on <b>{lastUpdatedFormatted}</b>
+                    </span>
+                )}
+            </div>
+            <h1 class="rb-headline">
+                <span class="rb-quiet">Clemency by</span><br />
+                {currentAdmin?.displayName ?? "the current administration"}.
+            </h1>
+            <p class="rb-deck">
+                Every federal pardon and commutation issued during the
+                current administration, newest first. Each entry links to
+                the original DOJ warrant. For
+                <a href="/search" class="rb-deck-link">previous administrations</a>
+                or filtered queries, use search. Subscribe via
+                <a href="/recent.xml" class="rb-deck-link">Atom feed</a>.
+            </p>
+        </header>
+
+        <div class="rb-feed" id="rb-feed">
+            {months.map((month, i) => {
+                const isInitiallyHidden = i >= INITIAL_VISIBLE_MONTHS;
+                return (
+                    <section
+                        class:list={[
+                            "rb-month",
+                            isInitiallyHidden && "rb-month-hidden",
+                        ]}
+                        data-month-rank={i}
+                        data-month-label={month.label}
+                    >
+                        <header class="rb-month-head">
+                            <h2 class="rb-month-title">{month.label}</h2>
+                            <p class="rb-month-summary">
+                                <b>
+                                    {month.entries.length}
+                                    {" "}
+                                    {month.entries.length === 1
+                                        ? "grant"
+                                        : "grants"}
+                                </b>
+                                {" — "}
+                                {month.pardons > 0 && (
+                                    <span>
+                                        {month.pardons}
+                                        {" "}
+                                        {month.pardons === 1
+                                            ? "pardon"
+                                            : "pardons"}
+                                    </span>
+                                )}
+                                {month.pardons > 0 && month.commutations > 0 && ", "}
+                                {month.commutations > 0 && (
+                                    <span>
+                                        {month.commutations}
+                                        {" "}
+                                        {month.commutations === 1
+                                            ? "commutation"
+                                            : "commutations"}
+                                    </span>
+                                )}
+                                {month.restitution > 0 && (
+                                    <>
+                                        {". "}
+                                        <span class="rb-red">
+                                            {formatCompactMoney(
+                                                month.restitution,
+                                            )}
+                                        </span>{" "}
+                                        in restitution forgiven.
+                                    </>
+                                )}
+                            </p>
+                        </header>
+
+                        <div class="rb-entries">
+                            {month.entries.map((entry) => {
+                                const d = entry.data;
+                                const adminDisplay =
+                                    adminIndex.get(d.administration_slug)
+                                        ?.displayName ?? d.president_name;
+                                const catColor = getCategoryColor(
+                                    d.offense_category,
+                                );
+                                const catLabel = d.offense_category.replace(
+                                    /\b\w/g,
+                                    (c) => c.toUpperCase(),
+                                );
+                                const restitution = d.restitution ?? 0;
+                                const typeLabel =
+                                    d.clemency_type === "pardon"
+                                        ? "Pardon"
+                                        : "Commutation";
+                                return (
+                                    <a
+                                        class="rb-entry"
+                                        href={`/pardon/details/${d.slug}`}
+                                        data-grant-slug={d.slug}
+                                        data-grant-date={d.grant_date}
+                                    >
+                                        <div class="rb-day" aria-hidden="true">
+                                            {dayLabel(d.grant_date)}
+                                        </div>
+                                        <div class="rb-body">
+                                            <div class="rb-who">
+                                                {d.recipient_name}
+                                                <span
+                                                    class:list={[
+                                                        "rb-type-tag",
+                                                        d.clemency_type ===
+                                                            "pardon"
+                                                            ? "rb-type-pardon"
+                                                            : "rb-type-commutation",
+                                                    ]}
+                                                >
+                                                    {typeLabel}
+                                                </span>
+                                            </div>
+                                            <div class="rb-what">
+                                                <span
+                                                    class="rb-cat-dot"
+                                                    style={`background:${catColor};`}
+                                                    aria-hidden="true"
+                                                ></span>
+                                                <span
+                                                    class="rb-cat-label"
+                                                    style={`color:${catColor};`}
+                                                >
+                                                    {catLabel}
+                                                </span>
+                                                {d.offense && (
+                                                    <span class="rb-offense">
+                                                        {" · "}
+                                                        {d.offense}
+                                                    </span>
+                                                )}
+                                                {d.district && (
+                                                    <span class="rb-district">
+                                                        {" · "}
+                                                        {d.district}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+                                        <div class="rb-pres">
+                                            <a
+                                                href={`/president/${d.administration_slug}`}
+                                                class="rb-pres-link"
+                                                onclick="event.stopPropagation();"
+                                                data-admin-slug={d.administration_slug}
+                                            >
+                                                {adminDisplay}
+                                            </a>
+                                        </div>
+                                        <div
+                                            class:list={[
+                                                "rb-money",
+                                                restitution === 0 &&
+                                                    "rb-money-zero",
+                                            ]}
+                                        >
+                                            {restitution > 0
+                                                ? formatCompactMoney(restitution)
+                                                : "no restitution"}
+                                        </div>
+                                        <div
+                                            class="rb-arr"
+                                            aria-hidden="true"
+                                        >→</div>
+                                    </a>
+                                );
+                            })}
+                        </div>
+                    </section>
+                );
+            })}
+        </div>
+
+        <div class="rb-feed-foot">
+            {months.length > INITIAL_VISIBLE_MONTHS && (
+                <button
+                    type="button"
+                    id="rb-load-older"
+                    class="rb-load-older"
+                >
+                    Load older
+                </button>
+            )}
+            <div class="rb-feed-end">
+                <p>
+                    This feed shows
+                    {" "}
+                    {sortedGrants.length.toLocaleString()}
+                    {" "}
+                    {sortedGrants.length === 1 ? "grant" : "grants"} from
+                    the current administration. For previous presidents'
+                    records, including all 3,205 grants since 1993, use
+                    search with administration and date filters.
+                </p>
+                <a href="/search" class="rb-feed-end-cta">
+                    Open full search →
+                </a>
+            </div>
+        </div>
+    </main>
+</Layout>
+
+<script
+    is:inline
+    define:vars={{ initialVisible: INITIAL_VISIBLE_MONTHS }}
+>
+    document.addEventListener("DOMContentLoaded", () => {
+        const monthBlocks = Array.from(
+            document.querySelectorAll(".rb-month[data-month-rank]"),
+        );
+        const button = document.getElementById("rb-load-older");
+        let revealed = initialVisible;
+
+        function updateButton() {
+            if (!button) return;
+            if (revealed >= monthBlocks.length) {
+                button.hidden = true;
+            }
+        }
+
+        button?.addEventListener("click", () => {
+            if (revealed >= monthBlocks.length) return;
+            const next = monthBlocks[revealed];
+            next.classList.remove("rb-month-hidden");
+            const monthLabel = next.getAttribute("data-month-label");
+            const rank = Number(next.getAttribute("data-month-rank"));
+            window.posthog?.capture("recent_month_loaded", {
+                month: monthLabel,
+                rank,
+            });
+            revealed += 1;
+            updateButton();
+            // Scroll the newly-revealed section into view (top of viewport)
+            next.scrollIntoView({ behavior: "smooth", block: "start" });
+        });
+        updateButton();
+
+        // Track entry clicks (separate from president link inside the entry)
+        document
+            .querySelectorAll("a.rb-entry[data-grant-slug]")
+            .forEach((entry) => {
+                entry.addEventListener("click", (e) => {
+                    // Don't double-fire when the user clicked the inner president link
+                    if (
+                        e.target instanceof HTMLElement &&
+                        e.target.closest(".rb-pres-link")
+                    ) {
+                        return;
+                    }
+                    window.posthog?.capture("recent_entry_clicked", {
+                        slug: entry.getAttribute("data-grant-slug"),
+                        date: entry.getAttribute("data-grant-date"),
+                    });
+                });
+            });
+
+        // Track president-link clicks within entries
+        document
+            .querySelectorAll("a.rb-pres-link[data-admin-slug]")
+            .forEach((link) => {
+                link.addEventListener("click", () => {
+                    window.posthog?.capture("administration_clicked", {
+                        slug: link.getAttribute("data-admin-slug"),
+                        source: "recent_feed",
+                    });
+                });
+            });
+    });
+</script>
+
+<style>
+    .recent-bold {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 0 40px;
+    }
+
+    /* Breadcrumb */
+    .rb-crumb {
+        padding: 28px 0 0;
+        font-size: 12px;
+        color: var(--text-muted);
+        display: flex;
+        gap: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+    }
+    .rb-crumb a {
+        color: var(--text-muted);
+        text-decoration: none;
+    }
+    .rb-crumb a:hover {
+        color: var(--text-primary);
+    }
+    .rb-crumb-sep {
+        color: var(--border-soft);
+    }
+    .rb-crumb-here {
+        color: var(--text-body);
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    /* Masthead */
+    .rb-mast {
+        padding: 32px 0 48px;
+        border-bottom: var(--rule-emphasis);
+    }
+    .rb-mast-top {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 24px;
+        margin-bottom: 28px;
+        flex-wrap: wrap;
+    }
+    .rb-stamp {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--accent);
+        padding: 6px 12px;
+        background: var(--accent-tint);
+        border-radius: 2px;
+    }
+    .rb-stamp-dot {
+        width: 6px;
+        height: 6px;
+        background: var(--accent);
+        border-radius: 50%;
+        animation: rb-pulse 1.6s ease-in-out infinite;
+    }
+    @keyframes rb-pulse {
+        0%,
+        100% {
+            opacity: 1;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 0.4;
+            transform: scale(0.7);
+        }
+    }
+    .rb-updated {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--text-faint);
+        font-weight: 500;
+    }
+    .rb-updated b {
+        color: var(--text-body);
+        font-weight: 500;
+    }
+    .rb-headline {
+        font-family: var(--serif);
+        font-size: 76px;
+        letter-spacing: -0.03em;
+        line-height: 0.95;
+        margin: 0 0 24px 0;
+        max-width: 920px;
+        font-weight: 400;
+        color: var(--text-primary);
+    }
+    .rb-quiet {
+        color: var(--text-faint);
+    }
+    .rb-red {
+        color: var(--accent);
+    }
+    .rb-deck {
+        font-size: 17px;
+        color: var(--text-body);
+        line-height: 1.6;
+        max-width: 700px;
+        margin: 0;
+    }
+    .rb-deck-link {
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-border);
+        text-decoration: none;
+    }
+    .rb-deck-link:hover {
+        border-bottom-color: var(--accent);
+    }
+
+    /* Feed */
+    .rb-feed {
+        padding: 0;
+    }
+    .rb-month {
+        padding: 48px 0 0;
+        border-bottom: 1px solid var(--border-default);
+    }
+    .rb-month-hidden {
+        display: none;
+    }
+    .rb-month-head {
+        display: grid;
+        grid-template-columns: 240px 1fr;
+        gap: 40px;
+        align-items: baseline;
+        margin-bottom: 28px;
+    }
+    .rb-month-title {
+        font-family: var(--serif);
+        font-size: 36px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+        margin: 0;
+        font-weight: 400;
+    }
+    .rb-month-summary {
+        font-size: 14px;
+        color: var(--text-secondary);
+        line-height: 1.65;
+        max-width: 580px;
+        margin: 0;
+    }
+    .rb-month-summary b {
+        color: var(--text-primary);
+        font-weight: 500;
+    }
+
+    /* Entries */
+    .rb-entries {
+        display: flex;
+        flex-direction: column;
+    }
+    .rb-entry {
+        display: grid;
+        grid-template-columns: 80px 1fr 220px 140px 24px;
+        gap: 32px;
+        padding: 22px 0;
+        border-top: 1px solid var(--border-default);
+        align-items: start;
+        text-decoration: none;
+        color: var(--text-primary);
+        transition: background 0.15s;
+    }
+    .rb-entry:hover {
+        background: var(--bg-card);
+    }
+    .rb-entry:hover .rb-arr {
+        color: var(--accent);
+    }
+    .rb-day {
+        font-family: var(--serif);
+        font-size: 32px;
+        color: var(--text-primary);
+        letter-spacing: -0.02em;
+        line-height: 1;
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+    }
+    .rb-body {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        min-width: 0;
+    }
+    .rb-who {
+        font-family: var(--serif);
+        font-size: 22px;
+        letter-spacing: -0.01em;
+        line-height: 1.2;
+    }
+    .rb-type-tag {
+        display: inline-block;
+        font-family: var(--sans);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: 500;
+        padding: 2px 8px;
+        border-radius: 2px;
+        vertical-align: middle;
+        margin-left: 10px;
+        position: relative;
+        top: -3px;
+    }
+    .rb-type-pardon {
+        background: var(--accent-tint);
+        color: var(--accent);
+    }
+    .rb-type-commutation {
+        background: rgba(42, 106, 122, 0.1);
+        color: #2a6a7a;
+    }
+    .rb-what {
+        font-size: 13px;
+        color: var(--text-secondary);
+        line-height: 1.55;
+    }
+    .rb-cat-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        margin-right: 6px;
+        vertical-align: middle;
+        position: relative;
+        top: -1px;
+    }
+    .rb-cat-label {
+        font-weight: 500;
+    }
+    .rb-offense,
+    .rb-district {
+        color: var(--text-secondary);
+    }
+    .rb-pres {
+        font-size: 13px;
+        color: var(--text-body);
+        padding-top: 4px;
+        min-width: 0;
+    }
+    .rb-pres-link {
+        color: var(--text-body);
+        text-decoration: none;
+        border-bottom: 1px solid transparent;
+        transition: border-color 0.15s, color 0.15s;
+    }
+    .rb-pres-link:hover {
+        color: var(--text-primary);
+        border-bottom-color: var(--border-soft);
+    }
+    .rb-money {
+        text-align: right;
+        font-family: var(--serif);
+        font-size: 20px;
+        color: var(--accent);
+        font-variant-numeric: tabular-nums;
+        letter-spacing: -0.01em;
+        padding-top: 6px;
+    }
+    .rb-money-zero {
+        color: var(--text-ghost);
+        font-family: var(--sans);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+    }
+    .rb-arr {
+        text-align: right;
+        color: var(--text-faint);
+        padding-top: 8px;
+        font-size: 18px;
+        transition: color 0.15s;
+    }
+
+    /* Feed footer */
+    .rb-feed-foot {
+        padding: 56px 0 80px;
+        border-top: 1px solid var(--border-default);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 36px;
+    }
+    .rb-load-older {
+        background: transparent;
+        border: 1px solid var(--border-soft);
+        color: var(--text-body);
+        font-family: inherit;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: 500;
+        padding: 14px 36px;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+    }
+    .rb-load-older:hover {
+        background: var(--bg-muted);
+        border-color: var(--text-muted);
+        color: var(--text-primary);
+    }
+    .rb-feed-end {
+        text-align: center;
+        max-width: 520px;
+    }
+    .rb-feed-end p {
+        font-size: 14px;
+        color: var(--text-secondary);
+        line-height: 1.6;
+        margin: 0 0 16px 0;
+    }
+    .rb-feed-end-cta {
+        display: inline-block;
+        font-size: 13px;
+        color: var(--accent);
+        border-bottom: 1px solid var(--accent-border);
+        padding-bottom: 1px;
+        text-decoration: none;
+    }
+    .rb-feed-end-cta:hover {
+        border-bottom-color: var(--accent);
+    }
+
+    /* Responsive */
+    @media (max-width: 900px) {
+        .recent-bold {
+            padding: 0 20px;
+        }
+        .rb-headline {
+            font-size: 44px;
+        }
+        .rb-mast {
+            padding: 24px 0 32px;
+        }
+        .rb-month {
+            padding: 32px 0 0;
+        }
+        .rb-month-head {
+            grid-template-columns: 1fr;
+            gap: 8px;
+            margin-bottom: 16px;
+        }
+        .rb-month-title {
+            font-size: 28px;
+        }
+        .rb-entry {
+            grid-template-columns: 48px 1fr;
+            grid-template-areas:
+                "day body"
+                ".   pres"
+                ".   money";
+            row-gap: 8px;
+            gap: 16px;
+            padding: 18px 0;
+        }
+        .rb-day {
+            grid-area: day;
+            font-size: 24px;
+        }
+        .rb-body {
+            grid-area: body;
+        }
+        .rb-pres {
+            grid-area: pres;
+            padding-top: 0;
+        }
+        .rb-money {
+            grid-area: money;
+            text-align: left;
+            padding-top: 0;
+            font-size: 17px;
+        }
+        .rb-arr {
+            display: none;
+        }
+        .rb-who {
+            font-size: 18px;
+        }
+        .rb-feed-foot {
+            padding: 40px 0 60px;
+            gap: 24px;
+        }
+    }
+</style>

--- a/src/pages/recent.astro
+++ b/src/pages/recent.astro
@@ -368,6 +368,7 @@ function dayLabel(isoDate: string): string {
                     window.posthog?.capture("recent_entry_clicked", {
                         slug: entry.getAttribute("data-grant-slug"),
                         date: entry.getAttribute("data-grant-date"),
+                        source: "recent_feed",
                     });
                 });
             });

--- a/src/pages/recent.xml.ts
+++ b/src/pages/recent.xml.ts
@@ -2,17 +2,32 @@ import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import { siteConfig } from "../config/site";
 import { buildAtomFeed } from "../lib/atom-feed";
+import { getCurrentAdministration } from "../lib/president-names";
 
 export const prerender = true;
 
 export const GET: APIRoute = async () => {
   const allGrants = await getCollection("pardonDetails");
 
-  const xml = buildAtomFeed(allGrants, {
+  // Scope: current administration only — pairs with the /recent HTML page.
+  // Earlier admins live in /search.
+  const currentAdmin = getCurrentAdministration(allGrants);
+  const currentGrants = currentAdmin
+    ? allGrants.filter(
+        (e) => e.data.administration_slug === currentAdmin.slug,
+      )
+    : [];
+
+  const adminLabel = currentAdmin?.displayName ?? "the current administration";
+
+  const xml = buildAtomFeed(currentGrants, {
     siteUrl: siteConfig.siteUrl,
-    feedTitle: `${siteConfig.name} — Recent Clemency Grants`,
-    feedSubtitle: siteConfig.description,
+    feedTitle: `${siteConfig.name} — Clemency by ${adminLabel}`,
+    feedSubtitle: `Federal pardons and commutations issued by ${adminLabel}, newest first.`,
     authorName: siteConfig.name,
+    // Pass the full set so term-count derivation produces correct
+    // "(Second Term)" suffixes even though we render Trump-2 only.
+    termContextEntries: allGrants,
   });
 
   return new Response(xml, {

--- a/src/pages/recent.xml.ts
+++ b/src/pages/recent.xml.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { siteConfig } from "../config/site";
+import { buildAtomFeed } from "../lib/atom-feed";
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+  const allGrants = await getCollection("pardonDetails");
+
+  const xml = buildAtomFeed(allGrants, {
+    siteUrl: siteConfig.siteUrl,
+    feedTitle: `${siteConfig.name} — Recent Clemency Grants`,
+    feedSubtitle: siteConfig.description,
+    authorName: siteConfig.name,
+  });
+
+  return new Response(xml, {
+    headers: { "Content-Type": "application/atom+xml; charset=utf-8" },
+  });
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -559,7 +559,6 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
                 president: state.president !== 'all' ? state.president : null,
                 category: state.category || null,
               },
-              source: 'desktop',
             });
           }
         }, 600);
@@ -604,6 +603,11 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         const btn = e.target.closest('[data-action]');
         if (!btn) return;
         const action = btn.dataset.action;
+        const priorFilterCount =
+          (state.search ? 1 : 0) +
+          (state.type ? 1 : 0) +
+          (state.president !== 'all' ? 1 : 0) +
+          (state.category ? 1 : 0);
         if (action === 'clear-search') {
           state.search = '';
           if (searchInput) searchInput.value = '';
@@ -621,6 +625,7 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         applyState();
         window.posthog?.capture('search_filters_cleared', {
           source: 'pill_remove',
+          filter_count: priorFilterCount,
           filter_type: action,
         });
       });

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SectionHeader from '../components/SectionHeader.astro';
 import '../styles/global.css';
 
 import { getCollection } from "astro:content";
@@ -56,6 +57,9 @@ const searchResults = sortedGrants.map((entry) => {
         restitution: d.restitution ?? 0,
         fine: d.fine ?? 0,
         administrationSlug: d.administration_slug,
+        // Per-row admin display name & last-name shorthand for the table cell
+        adminDisplay: administrationIndex.get(d.administration_slug)?.displayName ?? d.president_name,
+        presidentLastName: d.president_name.split(" ").slice(-1)[0],
     };
 });
 
@@ -78,177 +82,100 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
   ogImage="/og/search.png"
   currentPath={currentPath}
 >
-  <div class="max-w-search mx-auto px-5 md:px-10 py-10 md:py-section">
-    <p class="overline">Clemency Database</p>
-    <h1 class="text-page-title font-serif text-text-primary mb-2">Search Grants</h1>
-    <p class="text-nav text-text-faint mb-6">
-      Filter and search through all clemency grants.
-    </p>
+  <div class="search-page-bold max-w-search mx-auto px-5 md:px-10 py-10 md:py-section">
+    <SectionHeader
+      title={`Search ${searchResults.length.toLocaleString()} grants.`}
+      deck="Every federal pardon and commutation since 1993, sourced from the DOJ Office of the Pardon Attorney. Filter by administration, type, category, or date."
+    />
 
-    <div class="search-sticky-bar">
-      <div class="search-input-wrapper">
-        <svg aria-hidden="true" class="search-input-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="8" />
-          <line x1="21" y1="21" x2="16.65" y2="16.65" />
-        </svg>
-        <label for="mobile-search-input" class="sr-only">Search grants by name or offense</label>
-        <input
-          id="mobile-search-input"
-          type="text"
-          placeholder="Name or offense…"
-          class="search-input-sticky"
-          autocomplete="off"
-        />
-      </div>
-      <div class="search-sticky-meta">
-        <span id="mobile-count" class="search-sticky-count">{searchResults.length.toLocaleString()}</span>
-        <span id="mobile-count-total" class="search-sticky-count-total">of {searchResults.length.toLocaleString()}</span>
-        <span class="search-sticky-count-label">grants</span>
-        <button type="button" id="mobile-clear-all" class="search-sticky-clear" hidden>Clear all</button>
-      </div>
-    </div>
-
-    <nav class="president-chip-rail" aria-label="Filter by administration">
-      <div class="president-chip-rail-inner" id="president-chip-rail">
-        <label class="president-chip" data-president-chip="all">
-          <input type="radio" name="president-mobile" value="all" checked class="sr-only" />
-          <span class="president-chip-label">All <span class="president-chip-count" data-chip-count-for="all">{searchResults.length.toLocaleString()}</span></span>
-        </label>
-        {sortedAdmins.map((admin) => (
-          <label class="president-chip" data-president-chip={admin.slug}>
-            <input type="radio" name="president-mobile" value={admin.slug} class="sr-only" />
-            <span class="president-chip-label">{admin.displayName} <span class="president-chip-count" data-chip-count-for={admin.slug}>{admin.count.toLocaleString()}</span></span>
-          </label>
+    <!-- Top-level filter bar (4 dropdowns): search input + Type + Category + President.
+         The Sort select is gated on a separate issue (#46); until then, results
+         are sorted newest-first. -->
+    <div class="sb-filter-bar">
+      <label for="search-input" class="sr-only">Search by name or offense</label>
+      <input
+        id="search-input"
+        type="text"
+        class="sb-search-input"
+        placeholder="Search by name, offense, district…"
+        autocomplete="off"
+      />
+      <label for="type-select" class="sr-only">Filter by grant type</label>
+      <select id="type-select" class="sb-select">
+        <option value="">All grant types</option>
+        <option value="pardon">Pardons only</option>
+        <option value="commutation">Commutations only</option>
+      </select>
+      <label for="category-select" class="sr-only">Filter by offense category</label>
+      <select id="category-select" class="sb-select">
+        <option value="">All categories</option>
+        {sortedCategories.map((key) => (
+          <option value={key}>
+            {formatCategoryName(key)} ({categoryCounts[key].toLocaleString()})
+          </option>
         ))}
-      </div>
-    </nav>
-
-    <div class="search-layout">
-      <aside class="search-sidebar">
-        <details class="search-sidebar-disclosure" id="sidebar-disclosure">
-          <summary class="search-sidebar-summary">
-            <span>Filters <span id="sidebar-active-count" class="text-text-faint"></span></span>
-            <span class="search-sidebar-summary-caret" aria-hidden="true"></span>
-          </summary>
-
-          <div class="search-sidebar-body">
-            <div class="search-sidebar-section" data-mobile-hidden>
-              <p class="overline">President</p>
-              <fieldset id="president-facets">
-                <legend class="sr-only">Filter by administration</legend>
-                <label class="facet-row" data-president="all">
-                  <span class="facet-row-label">
-                    <input type="radio" name="president" value="all" checked />
-                    <span>All</span>
-                  </span>
-                  <span class="facet-row-count" data-count-for="all">{searchResults.length.toLocaleString()}</span>
-                </label>
-                {sortedAdmins.map((admin) => (
-                  <label class="facet-row" data-president={admin.slug}>
-                    <span class="facet-row-label">
-                      <input type="radio" name="president" value={admin.slug} />
-                      <span>{admin.displayName}</span>
-                    </span>
-                    <span class="facet-row-count" data-count-for={admin.slug}>{admin.count.toLocaleString()}</span>
-                  </label>
-                ))}
-              </fieldset>
-            </div>
-
-            <div class="search-sidebar-section" data-mobile-hidden>
-              <p class="overline">Search</p>
-              <div class="search-input-wrapper">
-                <svg aria-hidden="true" class="search-input-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <circle cx="11" cy="11" r="8" />
-                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
-                </svg>
-                <label for="search-input" class="sr-only">Search grants by name or offense</label>
-                <input
-                  id="search-input"
-                  type="text"
-                  placeholder="Name or offense…"
-                  class="search-input-sidebar"
-                  autocomplete="off"
-                />
-              </div>
-            </div>
-
-            <div class="search-sidebar-section">
-              <p class="overline">Date (or earlier)</p>
-              <label for="date-input" class="sr-only">Show grants on this date or earlier</label>
-              <input
-                id="date-input"
-                type="date"
-                class="date-input-sidebar"
-              />
-            </div>
-
-            <div class="search-sidebar-section">
-              <p class="overline">Grant Type</p>
-              <fieldset id="type-segmented" class="type-segmented">
-                <legend class="sr-only">Filter by grant type</legend>
-                <label>
-                  <input type="radio" name="type" value="" class="sr-only" checked />
-                  <span class="type-segmented-option">All</span>
-                </label>
-                <label>
-                  <input type="radio" name="type" value="pardon" class="sr-only" />
-                  <span class="type-segmented-option">Pardon</span>
-                </label>
-                <label>
-                  <input type="radio" name="type" value="commutation" class="sr-only" />
-                  <span class="type-segmented-option">Commutation</span>
-                </label>
-              </fieldset>
-            </div>
-
-            <div class="search-sidebar-section">
-              <p class="overline">Category</p>
-              <fieldset id="category-facets">
-                <legend class="sr-only">Filter by offense category</legend>
-                {sortedCategories.map((key) => (
-                  <label class="facet-row" data-category={key}>
-                    <span class="facet-row-label">
-                      <input type="checkbox" name="category" value={key} />
-                      <span>{formatCategoryName(key)}</span>
-                    </span>
-                    <span class="facet-row-count" data-count-for-category={key}>{categoryCounts[key].toLocaleString()}</span>
-                  </label>
-                ))}
-              </fieldset>
-            </div>
-          </div>
-        </details>
-      </aside>
-
-      <section class="search-main min-w-0">
-        <div id="filter-summary" class="filter-summary">
-          <span>
-            <span id="filter-summary-count" class="filter-summary-count">{searchResults.length.toLocaleString()}</span>
-            <span class="filter-summary-total">of {searchResults.length.toLocaleString()} grants</span>
-          </span>
-          <span class="filter-summary-sep" aria-hidden="true"></span>
-          <div id="filter-summary-chips" class="flex flex-wrap items-center gap-2"></div>
-          <button type="button" id="filter-summary-clear" class="filter-summary-clear" hidden>Clear all</button>
-        </div>
-
-        <div id="a11y-results-announce" class="sr-only" aria-live="polite" role="status"></div>
-
-        <div id="results-list" class="results-swap"></div>
-
-        <nav
-          id="pagination-controls"
-          class="pagination"
-          aria-label="Search results pagination"
-          hidden
-        ></nav>
-
-        <div id="empty-state" class="hidden text-center py-16">
-          <p class="text-text-faint text-lg mb-2">No results found</p>
-          <p class="text-text-faint text-sm">Try adjusting your filters or search terms.</p>
-        </div>
-      </section>
+      </select>
+      <label for="president-select" class="sr-only">Filter by administration</label>
+      <select id="president-select" class="sb-select">
+        <option value="all">All presidents</option>
+        {sortedAdmins.map((admin) => (
+          <option value={admin.slug}>
+            {admin.displayName} ({admin.count.toLocaleString()})
+          </option>
+        ))}
+      </select>
     </div>
+
+    <!-- Dynamic current-view headline. Reads the filter state and produces a
+         narrative summary like "Fraud pardons by Donald J. Trump (Second Term)
+         matching \"manafort\"". Updated by applyState() in the inline JS. -->
+    <div class="sb-current-view">
+      <h2 id="current-view-headline" class="sb-current-view-headline">
+        All grants
+      </h2>
+      <p class="sb-current-view-meta">
+        <span id="filter-summary-count" class="sb-current-view-count">{searchResults.length.toLocaleString()}</span>
+        of {searchResults.length.toLocaleString()} grants
+        <span class="sb-current-view-sep" aria-hidden="true">·</span>
+        Sorted by date — newest first
+      </p>
+    </div>
+
+    <!-- Active filter pills row -->
+    <div id="filter-summary" class="sb-active-filters" role="status" aria-live="polite">
+      <span class="sb-active-prefix">Filters</span>
+      <div id="filter-summary-chips" class="sb-active-chips"></div>
+      <button type="button" id="filter-summary-clear" class="sb-clear-all" hidden>Clear all</button>
+    </div>
+
+    <div id="a11y-results-announce" class="sr-only" aria-live="polite" role="status"></div>
+
+    <!-- Results table -->
+    <table class="sb-table" id="results-table">
+      <thead>
+        <tr>
+          <th class="sb-col-recipient">Recipient · Offense</th>
+          <th class="sb-col-type">Type</th>
+          <th class="sb-col-cat">Category</th>
+          <th class="sb-col-pres">President</th>
+          <th class="sb-col-date">Date</th>
+          <th class="sb-col-money num">Restitution</th>
+        </tr>
+      </thead>
+      <tbody id="results-body"></tbody>
+    </table>
+
+    <div id="empty-state" class="sb-empty-state hidden">
+      <p>No results found.</p>
+      <p class="sb-empty-state-deck">Try adjusting your filters or search terms.</p>
+    </div>
+
+    <nav
+      id="pagination-controls"
+      class="pagination"
+      aria-label="Search results pagination"
+      hidden
+    ></nav>
   </div>
 
   <script is:inline>
@@ -262,41 +189,33 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
       const TOTAL = grants.length;
 
       const searchInput = document.getElementById('search-input');
-      const dateInput = document.getElementById('date-input');
-      const typeSegmented = document.getElementById('type-segmented');
-      const presidentFacets = document.getElementById('president-facets');
-      const categoryFacets = document.getElementById('category-facets');
-      const resultsList = document.getElementById('results-list');
+      const typeSelect = document.getElementById('type-select');
+      const categorySelect = document.getElementById('category-select');
+      const presidentSelect = document.getElementById('president-select');
+      const currentViewHeadline = document.getElementById('current-view-headline');
+      const resultsBody = document.getElementById('results-body');
       const emptyState = document.getElementById('empty-state');
       const filterSummary = document.getElementById('filter-summary');
       const filterSummaryCount = document.getElementById('filter-summary-count');
       const filterSummaryChips = document.getElementById('filter-summary-chips');
       const filterSummaryClear = document.getElementById('filter-summary-clear');
-      const sidebarActiveCount = document.getElementById('sidebar-active-count');
       const a11yAnnounce = document.getElementById('a11y-results-announce');
-      const sidebarDisclosure = document.getElementById('sidebar-disclosure');
-      const mobileSearchInput = document.getElementById('mobile-search-input');
-      const mobileCount = document.getElementById('mobile-count');
-      const mobileCountTotal = document.getElementById('mobile-count-total');
-      const mobileClearAll = document.getElementById('mobile-clear-all');
-      const presidentChipRail = document.getElementById('president-chip-rail');
       const paginationControls = document.getElementById('pagination-controls');
 
       const presidentLabels = { all: 'All' };
-      presidentFacets.querySelectorAll('label[data-president]').forEach((label) => {
-        const slug = label.dataset.president;
-        const textSpan = label.querySelector('.facet-row-label > span:last-child');
-        if (textSpan) presidentLabels[slug] = textSpan.textContent;
+      Array.from(presidentSelect.options).forEach((opt) => {
+        // Strip the "(N)" count suffix to get the bare display name
+        const cleanLabel = opt.textContent.replace(/\s*\(\d[\d,]*\)\s*$/, '').trim();
+        presidentLabels[opt.value] = cleanLabel;
       });
 
-      const PAGE_SIZE = 10;
+      const PAGE_SIZE = 25;
 
       const state = {
         search: '',
         type: '',
-        date: '',
         president: 'all',
-        categories: new Set(),
+        category: '', // single-select per the bold mockup
         page: 1,
       };
 
@@ -312,9 +231,10 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
       }
 
       function formatRestitution(value) {
-        if (value >= 1000000) return `$${(value / 1000000).toFixed(1)}M`;
-        if (value >= 1000) return `$${Math.round(value / 1000)}K`;
-        return `$${value.toLocaleString()}`;
+        if (value >= 1_000_000_000) return '$' + (value / 1_000_000_000).toFixed(2).replace(/\.?0+$/, '') + 'B';
+        if (value >= 1_000_000) return '$' + (value / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+        if (value >= 1_000) return '$' + Math.round(value / 1_000) + 'K';
+        return '$' + value.toLocaleString();
       }
 
       function findInputByValue(root, name, value) {
@@ -328,22 +248,17 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
       function grantMatches(grant, skip) {
         if (!skip?.search && state.search) {
           const s = state.search.toLowerCase();
-          if (!grant.name.toLowerCase().includes(s) && !grant.offense.toLowerCase().includes(s)) {
+          if (
+            !grant.name.toLowerCase().includes(s) &&
+            !grant.offense.toLowerCase().includes(s) &&
+            !(grant.district || '').toLowerCase().includes(s)
+          ) {
             return false;
           }
         }
-        if (!skip?.type && state.type && grant.clemencyType !== state.type) {
-          return false;
-        }
-        if (!skip?.date && state.date && grant.grantDate > state.date) {
-          return false;
-        }
-        if (!skip?.president && state.president !== 'all' && grant.administrationSlug !== state.president) {
-          return false;
-        }
-        if (!skip?.categories && state.categories.size > 0 && !state.categories.has(grant.category)) {
-          return false;
-        }
+        if (!skip?.type && state.type && grant.clemencyType !== state.type) return false;
+        if (!skip?.president && state.president !== 'all' && grant.administrationSlug !== state.president) return false;
+        if (!skip?.category && state.category && grant.category !== state.category) return false;
         return true;
       }
 
@@ -351,256 +266,154 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         return grants.filter((g) => grantMatches(g));
       }
 
-      function computeFilteredCounts() {
-        const byPresident = { all: 0 };
-        const byCategory = {};
+      function buildHeadline() {
+        // Noun depends on the type filter
+        const noun =
+          state.type === 'pardon'
+            ? 'pardons'
+            : state.type === 'commutation'
+              ? 'commutations'
+              : 'grants';
 
-        for (const g of grants) {
-          if (grantMatches(g, { president: true })) {
-            byPresident.all += 1;
-            byPresident[g.administrationSlug] = (byPresident[g.administrationSlug] ?? 0) + 1;
-          }
-          if (grantMatches(g, { categories: true })) {
-            byCategory[g.category] = (byCategory[g.category] ?? 0) + 1;
-          }
+        // Build the descriptive phrase. Examples:
+        //   "All grants" (no filters)
+        //   "All pardons" (type=pardon)
+        //   "Fraud grants" (category=fraud)
+        //   "Fraud pardons by Donald J. Trump (Second Term)" (type+category+president)
+        //   "Grants by Joseph R. Biden matching \"hunter\"" (search+president)
+        let phrase;
+        if (state.category) {
+          phrase = formatCategoryName(state.category) + ' ' + noun;
+        } else if (state.president === 'all' && !state.search) {
+          phrase = 'All ' + noun;
+        } else {
+          phrase = noun;
         }
-        return { byPresident, byCategory };
+        if (state.president !== 'all') {
+          phrase += ' by ' + (presidentLabels[state.president] || state.president);
+        }
+        if (state.search) {
+          phrase += ' matching “' + state.search + '”';
+        }
+        // Capitalize first letter
+        return phrase.charAt(0).toUpperCase() + phrase.slice(1);
       }
 
-      function renderSidebarCounts(counts) {
-        presidentFacets.querySelectorAll('label[data-president]').forEach((label) => {
-          const slug = label.dataset.president;
-          const count = counts.byPresident[slug] ?? 0;
-          const countEl = label.querySelector('.facet-row-count');
-          if (countEl) countEl.textContent = count.toLocaleString();
-          const isCurrent = state.president === slug;
-          if (count === 0 && !isCurrent) {
-            label.classList.add('facet-row-disabled');
-          } else {
-            label.classList.remove('facet-row-disabled');
-          }
-        });
-
-        if (presidentChipRail) {
-          presidentChipRail.querySelectorAll('label[data-president-chip]').forEach((label) => {
-            const slug = label.dataset.presidentChip;
-            const count = counts.byPresident[slug] ?? 0;
-            const countEl = label.querySelector('[data-chip-count-for]');
-            if (countEl) countEl.textContent = count.toLocaleString();
-            const isCurrent = state.president === slug;
-            if (count === 0 && !isCurrent) {
-              label.classList.add('president-chip-disabled');
-            } else {
-              label.classList.remove('president-chip-disabled');
-            }
-          });
-        }
-
-        categoryFacets.querySelectorAll('label[data-category]').forEach((label) => {
-          const key = label.dataset.category;
-          const count = counts.byCategory[key] ?? 0;
-          const countEl = label.querySelector('.facet-row-count');
-          if (countEl) countEl.textContent = count.toLocaleString();
-          const isChecked = state.categories.has(key);
-          if (count === 0 && !isChecked) {
-            label.classList.add('facet-row-disabled');
-          } else {
-            label.classList.remove('facet-row-disabled');
-          }
-        });
-      }
-
-      function makeChip(label, action) {
+      function makePill(label, action) {
         const el = document.createElement('span');
-        el.className = 'filter-chip';
+        el.className = 'sb-pill';
         el.textContent = label + ' ';
-
         const btn = document.createElement('button');
         btn.type = 'button';
-        btn.className = 'filter-chip-remove';
+        btn.className = 'sb-pill-x';
         btn.setAttribute('aria-label', `Remove ${label} filter`);
         btn.dataset.action = action;
-        btn.textContent = '\u00D7';
+        btn.textContent = '×';
         el.appendChild(btn);
         return el;
       }
 
       function renderFilterSummary(filtered) {
         filterSummaryCount.textContent = filtered.length.toLocaleString();
-        if (mobileCount) mobileCount.textContent = filtered.length.toLocaleString();
 
-        const chips = [];
-        if (state.search) {
-          chips.push({ label: `"${state.search}"`, action: 'clear-search' });
-        }
-        if (state.type) {
-          chips.push({
-            label: state.type === 'pardon' ? 'Pardon' : 'Commutation',
-            action: 'clear-type',
-          });
-        }
-        if (state.date) {
-          chips.push({
-            label: 'On or before ' + formatDateLong(state.date),
-            action: 'clear-date',
-          });
-        }
+        const pills = [];
+        if (state.search) pills.push({ label: `"${state.search}"`, action: 'clear-search' });
+        if (state.type) pills.push({ label: state.type === 'pardon' ? 'Pardons' : 'Commutations', action: 'clear-type' });
         if (state.president !== 'all') {
-          chips.push({
-            label: presidentLabels[state.president] ?? state.president,
-            action: 'clear-president',
-          });
+          pills.push({ label: presidentLabels[state.president] ?? state.president, action: 'clear-president' });
         }
-        for (const cat of state.categories) {
-          chips.push({
-            label: formatCategoryName(cat),
-            action: 'clear-category:' + cat,
-          });
+        if (state.category) {
+          pills.push({ label: formatCategoryName(state.category), action: 'clear-category' });
         }
 
         filterSummaryChips.textContent = '';
-        for (const chip of chips) {
-          filterSummaryChips.appendChild(makeChip(chip.label, chip.action));
-        }
+        for (const p of pills) filterSummaryChips.appendChild(makePill(p.label, p.action));
 
-        filterSummaryClear.hidden = chips.length === 0;
-        const sep = filterSummary.querySelector('.filter-summary-sep');
-        if (sep) sep.hidden = chips.length === 0;
-        sidebarActiveCount.textContent = chips.length > 0 ? `(${chips.length} active)` : '';
-        if (mobileClearAll) mobileClearAll.hidden = chips.length === 0;
+        filterSummaryClear.hidden = pills.length === 0;
+        filterSummary.classList.toggle('is-empty', pills.length === 0);
 
-        const chipText = chips.map((c) => c.label).join(', ');
+        const chipText = pills.map((p) => p.label).join(', ');
         a11yAnnounce.textContent =
           `${filtered.length.toLocaleString()} of ${TOTAL.toLocaleString()} results` +
           (chipText ? `, filtered by ${chipText}` : '');
       }
 
       function renderResults(filtered) {
-        resultsList.classList.add('is-swapping');
-
         const start = (state.page - 1) * PAGE_SIZE;
-        const pageSlice = filtered.slice(start, start + PAGE_SIZE);
+        const slice = filtered.slice(start, start + PAGE_SIZE);
 
-        requestAnimationFrame(() => {
-          if (filtered.length === 0) {
-            resultsList.textContent = '';
-            emptyState.classList.remove('hidden');
-            resultsList.classList.remove('is-swapping');
-            return;
+        resultsBody.textContent = '';
+        if (filtered.length === 0) {
+          emptyState.classList.remove('hidden');
+          document.getElementById('results-table').classList.add('hidden');
+          return;
+        }
+        emptyState.classList.add('hidden');
+        document.getElementById('results-table').classList.remove('hidden');
+
+        for (const g of slice) {
+          const tr = document.createElement('tr');
+          tr.className = 'sb-row';
+          tr.dataset.slug = g.slug;
+
+          // Recipient · Offense
+          const tdName = document.createElement('td');
+          tdName.className = 'sb-cell-recipient';
+          const nameEl = document.createElement('div');
+          nameEl.className = 'sb-name';
+          nameEl.textContent = g.name;
+          const offenseEl = document.createElement('div');
+          offenseEl.className = 'sb-offense';
+          offenseEl.textContent = g.offense + (g.district ? ' · ' + g.district : '');
+          tdName.appendChild(nameEl);
+          tdName.appendChild(offenseEl);
+
+          // Type
+          const tdType = document.createElement('td');
+          const typeBadge = document.createElement('span');
+          typeBadge.className = 'sb-type-tag sb-type-tag-' + g.clemencyType;
+          typeBadge.textContent = g.clemencyType === 'pardon' ? 'Pardon' : 'Commutation';
+          tdType.appendChild(typeBadge);
+
+          // Category
+          const tdCat = document.createElement('td');
+          tdCat.className = 'sb-cell-cat';
+          const dot = document.createElement('span');
+          dot.className = 'sb-row-dot';
+          dot.style.backgroundColor = categoryColorMap[g.category] || '#7A7870';
+          tdCat.appendChild(dot);
+          const catText = document.createElement('span');
+          catText.textContent = formatCategoryName(g.category);
+          tdCat.appendChild(catText);
+
+          // President
+          const tdPres = document.createElement('td');
+          tdPres.className = 'sb-cell-pres';
+          tdPres.textContent = g.adminDisplay;
+
+          // Date
+          const tdDate = document.createElement('td');
+          tdDate.className = 'sb-cell-date';
+          tdDate.textContent = g.date;
+
+          // Restitution
+          const tdMoney = document.createElement('td');
+          tdMoney.className = 'sb-cell-money num';
+          if (g.restitution > 0) {
+            tdMoney.textContent = formatRestitution(g.restitution);
+          } else {
+            tdMoney.textContent = '—';
+            tdMoney.classList.add('sb-money-zero');
           }
 
-          emptyState.classList.add('hidden');
-          resultsList.textContent = '';
-
-          pageSlice.forEach((grant, i) => {
-            const catLabel = formatCategoryName(grant.category);
-            const catColor = categoryColorMap[grant.category] || '#7A7870';
-            const typeLabel = grant.clemencyType === 'pardon' ? 'Pardon' : 'Commutation';
-
-            const card = document.createElement('a');
-            card.href = '/pardon/details/' + grant.slug;
-            card.className = 'search-card block no-underline mb-3' + (i < 10 ? ' animate-fade-in' : '');
-            card.style.borderLeftColor = catColor;
-            if (i < 10) card.style.animationDelay = (i * 35) + 'ms';
-
-            const outer = document.createElement('div');
-            outer.className = 'flex items-start gap-3';
-
-            const content = document.createElement('div');
-            content.className = 'flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 flex-1 min-w-0';
-
-            const left = document.createElement('div');
-            left.className = 'flex-1 min-w-0';
-
-            const nameEl = document.createElement('div');
-            nameEl.className = 'font-serif text-text-primary mb-1';
-            nameEl.style.fontSize = '17px';
-            nameEl.style.lineHeight = '1.25';
-            nameEl.textContent = grant.name;
-            left.appendChild(nameEl);
-
-            const metaLine = document.createElement('div');
-            metaLine.className = 'flex items-center gap-2 mb-2';
-            metaLine.style.fontSize = '11px';
-            metaLine.style.textTransform = 'uppercase';
-            metaLine.style.letterSpacing = '0.06em';
-
-            const typeEl = document.createElement('span');
-            typeEl.textContent = typeLabel;
-            typeEl.style.color = grant.clemencyType === 'pardon' ? '#c23b22' : '#2a6a7a';
-            typeEl.style.fontWeight = '500';
-            metaLine.appendChild(typeEl);
-
-            const sepEl = document.createElement('span');
-            sepEl.textContent = '\u00B7';
-            sepEl.style.color = '#b8b6ae';
-            metaLine.appendChild(sepEl);
-
-            const catEl = document.createElement('span');
-            catEl.textContent = catLabel;
-            catEl.style.color = catColor;
-            metaLine.appendChild(catEl);
-
-            left.appendChild(metaLine);
-
-            const offense = document.createElement('p');
-            offense.className = 'text-card-offense text-text-secondary line-clamp-2';
-            offense.textContent = grant.offense;
-            left.appendChild(offense);
-
-            if (grant.district || grant.sentence) {
-              const meta = document.createElement('div');
-              meta.className = 'flex flex-wrap gap-3 text-meta text-text-faint mt-1';
-              if (grant.district) {
-                const d = document.createElement('span');
-                d.textContent = grant.district;
-                meta.appendChild(d);
-              }
-              if (grant.sentence) {
-                const s = document.createElement('span');
-                s.textContent = grant.sentence;
-                meta.appendChild(s);
-              }
-              left.appendChild(meta);
-            }
-
-            content.appendChild(left);
-
-            const right = document.createElement('div');
-            right.className = 'flex sm:flex-col sm:text-right gap-3 sm:gap-0 sm:ml-4 flex-shrink-0 items-center sm:items-end';
-
-            const dateDiv = document.createElement('div');
-            dateDiv.className = 'text-meta text-text-faint sm:mb-1';
-            dateDiv.style.fontVariantNumeric = 'tabular-nums';
-            dateDiv.textContent = grant.date;
-            right.appendChild(dateDiv);
-
-            if (grant.restitution) {
-              const restVal = document.createElement('div');
-              restVal.className = 'text-body font-medium text-accent';
-              restVal.textContent = formatRestitution(grant.restitution);
-              right.appendChild(restVal);
-
-              const restLabel = document.createElement('div');
-              restLabel.className = 'text-badge text-text-faint';
-              restLabel.textContent = 'restitution';
-              right.appendChild(restLabel);
-            }
-
-            content.appendChild(right);
-            outer.appendChild(content);
-
-            const chevron = document.createElement('span');
-            chevron.className = 'search-card-chevron hidden sm:block';
-            chevron.textContent = '\u203A';
-            outer.appendChild(chevron);
-
-            card.appendChild(outer);
-            resultsList.appendChild(card);
-          });
-
-          resultsList.classList.remove('is-swapping');
-        });
+          tr.appendChild(tdName);
+          tr.appendChild(tdType);
+          tr.appendChild(tdCat);
+          tr.appendChild(tdPres);
+          tr.appendChild(tdDate);
+          tr.appendChild(tdMoney);
+          resultsBody.appendChild(tr);
+        }
       }
 
       function buildPageList(current, total) {
@@ -636,7 +449,7 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         prev.type = 'button';
         prev.className = 'pagination-button';
         prev.dataset.pageAction = 'prev';
-        prev.textContent = '\u2039 Prev';
+        prev.textContent = '‹ Prev';
         prev.disabled = state.page <= 1;
         paginationControls.appendChild(prev);
 
@@ -645,7 +458,7 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
           if (p === 'ellipsis') {
             const span = document.createElement('span');
             span.className = 'pagination-ellipsis';
-            span.textContent = '\u2026';
+            span.textContent = '…';
             paginationControls.appendChild(span);
             continue;
           }
@@ -662,55 +475,32 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         next.type = 'button';
         next.className = 'pagination-button';
         next.dataset.pageAction = 'next';
-        next.textContent = 'Next \u203A';
+        next.textContent = 'Next ›';
         next.disabled = state.page >= totalPages;
         paginationControls.appendChild(next);
-      }
-
-      function syncUrl() {
-        const params = new URLSearchParams();
-        if (state.search) params.set('q', state.search);
-        if (state.type) params.set('type', state.type);
-        if (state.date) params.set('date', state.date);
-        if (state.president !== 'all') params.set('president', state.president);
-        if (state.categories.size > 0) params.set('categories', Array.from(state.categories).join(','));
-        if (state.page > 1) params.set('page', String(state.page));
-
-        const qs = params.toString();
-        const next = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
-        const current = window.location.pathname + window.location.search;
-        if (next !== current) {
-          history.replaceState(null, '', next);
-        }
       }
 
       function syncControlsFromState() {
         if (searchInput && document.activeElement !== searchInput && searchInput.value !== state.search) {
           searchInput.value = state.search;
         }
-        if (mobileSearchInput && document.activeElement !== mobileSearchInput && mobileSearchInput.value !== state.search) {
-          mobileSearchInput.value = state.search;
-        }
+        if (typeSelect.value !== state.type) typeSelect.value = state.type;
+        if (categorySelect.value !== state.category) categorySelect.value = state.category;
+        if (presidentSelect.value !== state.president) presidentSelect.value = state.president;
+      }
 
-        const typeRadio = findInputByValue(typeSegmented, 'type', state.type);
-        if (typeRadio && !typeRadio.checked) typeRadio.checked = true;
+      function syncUrl() {
+        const params = new URLSearchParams();
+        if (state.search) params.set('q', state.search);
+        if (state.type) params.set('type', state.type);
+        if (state.president !== 'all') params.set('president', state.president);
+        if (state.category) params.set('category', state.category);
+        if (state.page > 1) params.set('page', String(state.page));
 
-        if (dateInput && dateInput.value !== state.date) {
-          dateInput.value = state.date;
-        }
-
-        const desktopPres = findInputByValue(presidentFacets, 'president', state.president);
-        if (desktopPres && !desktopPres.checked) desktopPres.checked = true;
-
-        if (presidentChipRail) {
-          const mobilePres = findInputByValue(presidentChipRail, 'president-mobile', state.president);
-          if (mobilePres && !mobilePres.checked) mobilePres.checked = true;
-        }
-
-        categoryFacets.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
-          const shouldBeChecked = state.categories.has(cb.value);
-          if (cb.checked !== shouldBeChecked) cb.checked = shouldBeChecked;
-        });
+        const qs = params.toString();
+        const next = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+        const current = window.location.pathname + window.location.search;
+        if (next !== current) history.replaceState(null, '', next);
       }
 
       function applyState() {
@@ -721,9 +511,8 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         if (state.page < 1) state.page = 1;
         renderResults(filtered);
         renderPagination(filtered.length);
-        const counts = computeFilteredCounts();
-        renderSidebarCounts(counts);
         renderFilterSummary(filtered);
+        currentViewHeadline.textContent = buildHeadline();
         syncUrl();
       }
 
@@ -731,20 +520,19 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         const priorFilterCount =
           (state.search ? 1 : 0) +
           (state.type ? 1 : 0) +
-          (state.date ? 1 : 0) +
           (state.president !== 'all' ? 1 : 0) +
-          state.categories.size;
+          (state.category ? 1 : 0);
 
         state.search = '';
         state.type = '';
-        state.date = '';
         state.president = 'all';
-        state.categories.clear();
+        state.category = '';
         state.page = 1;
 
         if (searchInput) searchInput.value = '';
-        if (mobileSearchInput) mobileSearchInput.value = '';
-        if (dateInput) dateInput.value = '';
+        if (typeSelect) typeSelect.value = '';
+        if (categorySelect) categorySelect.value = '';
+        if (presidentSelect) presidentSelect.value = 'all';
 
         applyState();
         window.posthog?.capture('search_filters_cleared', {
@@ -754,8 +542,8 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
       }
 
       let searchDebounce;
-      function handleSearchInput(event) {
-        state.search = event.target.value.trim();
+      searchInput.addEventListener('input', (e) => {
+        state.search = e.target.value.trim();
         state.page = 1;
         applyState();
         clearTimeout(searchDebounce);
@@ -768,78 +556,47 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
               has_results: resultsCount > 0,
               active_filters: {
                 type: state.type || null,
-                date: state.date || null,
                 president: state.president !== 'all' ? state.president : null,
-                categories_count: state.categories.size,
+                category: state.category || null,
               },
-              source: event.target.id === 'mobile-search-input' ? 'mobile' : 'desktop',
+              source: 'desktop',
             });
           }
         }, 600);
-      }
-      searchInput.addEventListener('input', handleSearchInput);
-      if (mobileSearchInput) mobileSearchInput.addEventListener('input', handleSearchInput);
+      });
 
-      typeSegmented.addEventListener('change', (e) => {
-        const t = e.target;
-        if (t && t.name === 'type') {
-          state.type = t.value;
-          state.page = 1;
-          applyState();
-          if (state.type) {
-            window.posthog?.capture('type_filter_applied', { type: state.type });
-          }
+      typeSelect.addEventListener('change', (e) => {
+        state.type = e.target.value;
+        state.page = 1;
+        applyState();
+        if (state.type) {
+          window.posthog?.capture('type_filter_applied', { type: state.type });
         }
       });
 
-      if (dateInput) {
-        dateInput.addEventListener('change', (e) => {
-          state.date = e.target.value;
-          state.page = 1;
-          applyState();
-          if (state.date) {
-            window.posthog?.capture('date_filter_applied', { date: state.date });
-          }
-        });
-      }
-
-      presidentFacets.addEventListener('change', (e) => {
-        const t = e.target;
-        if (t && t.name === 'president') {
-          state.president = t.value;
-          state.page = 1;
-          applyState();
-          if (state.president !== 'all') {
-            window.posthog?.capture('president_filter_applied', { president: state.president, source: 'sidebar' });
-          }
+      categorySelect.addEventListener('change', (e) => {
+        const prev = state.category;
+        state.category = e.target.value;
+        state.page = 1;
+        applyState();
+        // Match the legacy event name + payload shape used by the prior facet UI
+        if (prev) {
+          window.posthog?.capture('category_filter_applied', { category: prev, checked: false });
+        }
+        if (state.category) {
+          window.posthog?.capture('category_filter_applied', { category: state.category, checked: true });
         }
       });
 
-      if (presidentChipRail) {
-        presidentChipRail.addEventListener('change', (e) => {
-          const t = e.target;
-          if (t && t.name === 'president-mobile') {
-            state.president = t.value;
-            state.page = 1;
-            applyState();
-            if (state.president !== 'all') {
-              window.posthog?.capture('president_filter_applied', { president: state.president, source: 'chip_rail' });
-            }
-          }
-        });
-      }
-
-      categoryFacets.addEventListener('change', (e) => {
-        const t = e.target;
-        if (t && t.name === 'category') {
-          if (t.checked) {
-            state.categories.add(t.value);
-          } else {
-            state.categories.delete(t.value);
-          }
-          state.page = 1;
-          applyState();
-          window.posthog?.capture('category_filter_applied', { category: t.value, checked: t.checked });
+      presidentSelect.addEventListener('change', (e) => {
+        state.president = e.target.value || 'all';
+        state.page = 1;
+        applyState();
+        if (state.president !== 'all') {
+          window.posthog?.capture('president_filter_applied', {
+            president: state.president,
+            source: 'pres_dropdown',
+          });
         }
       });
 
@@ -850,49 +607,46 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         if (action === 'clear-search') {
           state.search = '';
           if (searchInput) searchInput.value = '';
-          if (mobileSearchInput) mobileSearchInput.value = '';
         } else if (action === 'clear-type') {
           state.type = '';
-        } else if (action === 'clear-date') {
-          state.date = '';
-          if (dateInput) dateInput.value = '';
+          if (typeSelect) typeSelect.value = '';
         } else if (action === 'clear-president') {
           state.president = 'all';
-        } else if (action && action.startsWith('clear-category:')) {
-          const key = action.slice('clear-category:'.length);
-          state.categories.delete(key);
+          if (presidentSelect) presidentSelect.value = 'all';
+        } else if (action === 'clear-category') {
+          state.category = '';
+          if (categorySelect) categorySelect.value = '';
         }
         state.page = 1;
         applyState();
         window.posthog?.capture('search_filters_cleared', {
-          source: 'chip_remove',
+          source: 'pill_remove',
           filter_type: action,
         });
       });
 
       filterSummaryClear.addEventListener('click', () => clearAllFilters('clear_all_button'));
-      if (mobileClearAll) {
-        mobileClearAll.addEventListener('click', () => clearAllFilters('mobile_clear_all_button'));
-      }
 
-      resultsList.addEventListener('click', (e) => {
-        const card = e.target.closest('a.search-card');
-        if (!card) return;
-        const slug = card.href.split('/pardon/details/')[1];
-        const cards = Array.from(resultsList.children);
+      // Whole-row click → navigate to detail page (and capture analytics)
+      resultsBody.addEventListener('click', (e) => {
+        const tr = e.target.closest('tr.sb-row');
+        if (!tr) return;
+        const slug = tr.dataset.slug;
+        if (!slug) return;
+        const rows = Array.from(resultsBody.children);
         window.posthog?.capture('search_result_clicked', {
           slug,
           query: state.search || null,
-          position: cards.indexOf(card),
-          total_results: cards.length,
+          position: rows.indexOf(tr),
+          total_results: rows.length,
           page: state.page,
           has_active_filters:
             Boolean(state.search) ||
             Boolean(state.type) ||
-            Boolean(state.date) ||
             state.president !== 'all' ||
-            state.categories.size > 0,
+            Boolean(state.category),
         });
+        window.location.href = '/pardon/details/' + slug;
       });
 
       if (paginationControls) {
@@ -915,7 +669,7 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
 
           if (state.page !== prevPage) {
             applyState();
-            const target = document.getElementById('filter-summary') || resultsList;
+            const target = document.getElementById('results-table');
             if (target && typeof target.scrollIntoView === 'function') {
               target.scrollIntoView({ behavior: 'smooth', block: 'start' });
             }
@@ -928,12 +682,8 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
         });
       }
 
-      const desktopMq = window.matchMedia('(min-width: 1024px)');
-      if (sidebarDisclosure) sidebarDisclosure.open = desktopMq.matches;
-      desktopMq.addEventListener('change', (e) => {
-        if (e.matches && sidebarDisclosure) sidebarDisclosure.open = true;
-      });
-
+      // Initial state from URL — supports both new (dateMode/dateFrom/dateTo)
+      // and legacy (date) params for back-compat with bookmarks/links.
       const urlParams = new URLSearchParams(window.location.search);
 
       const qParam = urlParams.get('q');
@@ -945,46 +695,40 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
       const typeParam = urlParams.get('type');
       if (typeParam === 'pardon' || typeParam === 'commutation') {
         state.type = typeParam;
-        const radio = findInputByValue(typeSegmented, 'type', typeParam);
-        if (radio) radio.checked = true;
+        if (typeSelect) typeSelect.value = typeParam;
       }
 
-      const dateParam = urlParams.get('date');
-      if (dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
-        state.date = dateParam;
-        if (dateInput) dateInput.value = dateParam;
-      }
+      // Date params (?date, ?dateMode, ?dateFrom, ?dateTo) from prior versions
+      // are intentionally ignored — date filtering is no longer in the UI.
+      // Bookmarks with these params still load the page; they just don't apply.
 
       const presParam = urlParams.get('president');
       if (presParam) {
-        const pradio = findInputByValue(presidentFacets, 'president', presParam);
-        if (pradio) {
+        const exists = Array.from(presidentSelect.options).some((o) => o.value === presParam);
+        if (exists) {
           state.president = presParam;
-          pradio.checked = true;
+          presidentSelect.value = presParam;
         }
       }
 
-      const catsParam = urlParams.get('categories');
-      const legacyCatParam = urlParams.get('category');
-      const catsToApply = catsParam
-        ? catsParam.split(',')
-        : legacyCatParam
-          ? [legacyCatParam]
-          : [];
-      catsToApply.forEach((c) => {
-        const key = c.trim();
-        if (!key) return;
-        const cb = findInputByValue(categoryFacets, 'category', key);
-        if (cb) {
-          state.categories.add(key);
-          cb.checked = true;
+      // Single-select category. Accept both ?category=cat and the legacy
+      // ?categories=cat1,cat2 (taking the first entry) so old bookmarks work.
+      const catParam = urlParams.get('category');
+      const legacyCatsParam = urlParams.get('categories');
+      const initialCategory = catParam
+        ? catParam.trim()
+        : (legacyCatsParam ? legacyCatsParam.split(',')[0]?.trim() : '');
+      if (initialCategory) {
+        // Confirm the value exists in the select before applying
+        const exists = Array.from(categorySelect.options).some((o) => o.value === initialCategory);
+        if (exists) {
+          state.category = initialCategory;
+          categorySelect.value = initialCategory;
         }
-      });
+      }
 
       const pageParam = parseInt(urlParams.get('page') || '', 10);
-      if (!Number.isNaN(pageParam) && pageParam > 1) {
-        state.page = pageParam;
-      }
+      if (!Number.isNaN(pageParam) && pageParam > 1) state.page = pageParam;
 
       applyState();
     });
@@ -993,3 +737,362 @@ const categoryColorMap: Record<string, string> = Object.fromEntries(
   <script id="grants-data" type="application/json" set:html={JSON.stringify(searchResults)} />
   <script id="category-colors" type="application/json" set:html={JSON.stringify(categoryColorMap)} />
 </Layout>
+
+<style is:global>
+  .search-page-bold > .section-header {
+    border-top: none;
+    padding-top: 0;
+    padding-bottom: 32px;
+  }
+
+  /* ===== Filter bar (top) — search input + 3 selects (type, category, president) ===== */
+  .sb-filter-bar {
+    display: grid;
+    grid-template-columns: 1fr auto auto auto;
+    gap: 0;
+    border-top: var(--rule-emphasis);
+    border-bottom: 1px solid var(--border-default);
+  }
+  .sb-search-input {
+    background: transparent;
+    border: none;
+    border-right: 1px solid var(--border-default);
+    padding: 18px 20px;
+    font-size: 16px;
+    font-family: inherit;
+    color: var(--text-primary);
+    outline: none;
+    width: 100%;
+    min-width: 0;
+  }
+  .sb-search-input::placeholder {
+    color: var(--text-faint);
+  }
+  .sb-select {
+    background: transparent;
+    border: none;
+    border-right: 1px solid var(--border-default);
+    padding: 18px 36px 18px 20px;
+    font-size: 14px;
+    color: var(--text-primary);
+    font-family: inherit;
+    outline: none;
+    cursor: pointer;
+    min-width: 180px;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--text-faint) 50%),
+      linear-gradient(135deg, var(--text-faint) 50%, transparent 50%);
+    background-position: calc(100% - 18px) 22px, calc(100% - 13px) 22px;
+    background-size: 5px 5px;
+    background-repeat: no-repeat;
+  }
+  .sb-select:last-of-type {
+    border-right: none;
+  }
+  .sb-select:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+
+  /* ===== Current-view headline (replaces the wide president rail) ===== */
+  .sb-current-view {
+    padding: 36px 0 24px;
+  }
+  .sb-current-view-headline {
+    font-family: var(--serif);
+    font-size: 44px;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    margin: 0 0 12px 0;
+    color: var(--text-primary);
+    font-weight: 400;
+    text-wrap: balance;
+  }
+  .sb-current-view-meta {
+    font-size: 12px;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 500;
+    margin: 0;
+  }
+  .sb-current-view-count {
+    font-family: var(--serif);
+    font-size: 18px;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+    text-transform: none;
+  }
+  .sb-current-view-sep {
+    margin: 0 8px;
+    color: var(--border-soft);
+  }
+
+  /* ===== Active filter pills row ===== */
+  .sb-active-filters {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--border-default);
+    font-size: 12px;
+    color: var(--text-muted);
+    flex-wrap: wrap;
+    min-height: 48px;
+  }
+  .sb-active-filters.is-empty .sb-active-prefix {
+    color: var(--text-faint);
+  }
+  .sb-active-prefix {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+    font-weight: 500;
+  }
+  .sb-active-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .sb-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--accent-tint);
+    color: var(--accent);
+    padding: 5px 6px 5px 12px;
+    border-radius: 100px;
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .sb-pill-x {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: white;
+    cursor: pointer;
+    font-size: 11px;
+    border: none;
+    font-family: inherit;
+    padding: 0;
+    line-height: 1;
+  }
+  .sb-clear-all {
+    color: var(--text-faint);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-family: inherit;
+    font-weight: 500;
+    padding: 0;
+    margin-left: auto;
+  }
+  .sb-clear-all:hover {
+    color: var(--accent);
+  }
+
+  /* ===== Results table ===== */
+  table.sb-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+    border-top: 1px solid var(--border-default);
+  }
+  table.sb-table.hidden {
+    display: none;
+  }
+  table.sb-table thead th {
+    text-align: left;
+    font-weight: 500;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-faint);
+    padding: 14px 12px;
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-page);
+  }
+  table.sb-table thead th.num,
+  table.sb-table tbody td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  table.sb-table tbody tr {
+    border-bottom: 1px solid var(--border-default);
+    transition: background 0.1s;
+    cursor: pointer;
+  }
+  table.sb-table tbody tr:hover {
+    background: var(--bg-muted);
+  }
+  table.sb-table tbody td {
+    padding: 16px 12px;
+    vertical-align: top;
+  }
+  .sb-name {
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 400;
+    color: var(--text-primary);
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+  }
+  .sb-offense {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 4px;
+    line-height: 1.5;
+    max-width: 480px;
+  }
+  .sb-cell-pres {
+    font-size: 13px;
+    color: var(--text-body);
+  }
+  .sb-cell-date {
+    font-size: 13px;
+    color: var(--text-body);
+    font-variant-numeric: tabular-nums;
+  }
+  .sb-cell-money {
+    font-family: var(--serif);
+    font-size: 18px;
+    color: var(--accent);
+    letter-spacing: -0.005em;
+    line-height: 1.1;
+  }
+  .sb-cell-money.sb-money-zero {
+    color: var(--text-ghost);
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 400;
+  }
+  .sb-row-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    vertical-align: middle;
+    margin-right: 6px;
+    position: relative;
+    top: -1px;
+  }
+  .sb-cell-cat {
+    font-size: 12px;
+    color: var(--text-secondary);
+    text-transform: capitalize;
+  }
+  .sb-type-tag {
+    display: inline-block;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 2px 7px;
+    border-radius: 2px;
+    font-weight: 500;
+  }
+  .sb-type-tag-pardon {
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+  .sb-type-tag-commutation {
+    background: rgba(42, 106, 122, 0.1);
+    color: #2a6a7a;
+  }
+
+  /* Empty state */
+  .sb-empty-state {
+    padding: 80px 0;
+    text-align: center;
+    color: var(--text-muted);
+  }
+  .sb-empty-state.hidden {
+    display: none;
+  }
+  .sb-empty-state p {
+    font-family: var(--serif);
+    font-size: 24px;
+    margin: 0 0 8px 0;
+  }
+  .sb-empty-state-deck {
+    font-family: var(--sans) !important;
+    font-size: 13px !important;
+    color: var(--text-faint);
+  }
+
+  /* Pagination — bold restyle */
+  .search-page-bold .pagination {
+    border-top: var(--rule-emphasis);
+    margin-top: 32px;
+    padding-top: 20px;
+    justify-content: center;
+  }
+  .search-page-bold .pagination-button,
+  .search-page-bold .pagination-page {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 2px;
+  }
+  .search-page-bold .pagination-page.is-active {
+    background: var(--text-primary);
+    border-color: var(--text-primary);
+  }
+
+  /* Responsive */
+  @media (max-width: 900px) {
+    .sb-filter-bar {
+      grid-template-columns: 1fr;
+    }
+    .sb-search-input {
+      border-right: none;
+      border-bottom: 1px solid var(--border-default);
+    }
+    .sb-select {
+      border-right: none;
+      border-bottom: 1px solid var(--border-default);
+      width: 100%;
+    }
+    .sb-select:last-of-type {
+      border-bottom: none;
+    }
+
+    .sb-current-view {
+      padding: 24px 0 16px;
+    }
+    .sb-current-view-headline {
+      font-size: 28px;
+    }
+
+    table.sb-table thead {
+      display: none;
+    }
+    table.sb-table,
+    table.sb-table tbody,
+    table.sb-table tr,
+    table.sb-table td {
+      display: block;
+      width: 100%;
+    }
+    table.sb-table tbody tr {
+      padding: 18px 0;
+      border-bottom: 1px solid var(--border-default);
+    }
+    table.sb-table tbody td {
+      padding: 4px 0;
+      border: none;
+    }
+    .sb-cell-money {
+      font-size: 22px;
+    }
+  }
+</style>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -4,6 +4,7 @@ import '../styles/global.css';
 
 import { getCollection } from "astro:content";
 import { getAdministrationIndex } from "../lib/president-names";
+import { getCategoryColor } from "../lib/category-colors";
 
 const currentPath = Astro.url.pathname;
 
@@ -12,17 +13,6 @@ const administrationIndex = getAdministrationIndex(allGrants);
 const sortedAdmins = Array.from(administrationIndex.values()).sort((a, b) =>
     b.termStartDate.localeCompare(a.termStartDate),
 );
-
-const categoryColors: Record<string, string> = {
-    fraud: "#8A6B1E",
-    "drug offense": "#3A6A4A",
-    firearms: "#C23B22",
-    "FACE act": "#B8652A",
-    "financial crime": "#2A6A7A",
-    "violent crime": "#6A4B7A",
-    immigration: "#7A6A3A",
-    other: "#7A7870",
-};
 
 function formatCategoryName(key: string): string {
     return key.replace(/\b\w/g, (c) => c.toUpperCase());
@@ -76,6 +66,10 @@ for (const grant of searchResults) {
 const sortedCategories = Object.entries(categoryCounts)
     .sort(([, a], [, b]) => b - a)
     .map(([key]) => key);
+
+const categoryColorMap: Record<string, string> = Object.fromEntries(
+    sortedCategories.map((key) => [key, getCategoryColor(key)]),
+);
 ---
 
 <Layout
@@ -264,7 +258,7 @@ const sortedCategories = Object.entries(categoryCounts)
       if (!grantsDataEl || !colorsDataEl) return;
 
       const grants = JSON.parse(grantsDataEl.textContent);
-      const categoryColors = JSON.parse(colorsDataEl.textContent);
+      const categoryColorMap = JSON.parse(colorsDataEl.textContent);
       const TOTAL = grants.length;
 
       const searchInput = document.getElementById('search-input');
@@ -500,7 +494,7 @@ const sortedCategories = Object.entries(categoryCounts)
 
           pageSlice.forEach((grant, i) => {
             const catLabel = formatCategoryName(grant.category);
-            const catColor = categoryColors[grant.category] || '#7A7870';
+            const catColor = categoryColorMap[grant.category] || '#7A7870';
             const typeLabel = grant.clemencyType === 'pardon' ? 'Pardon' : 'Commutation';
 
             const card = document.createElement('a');
@@ -997,5 +991,5 @@ const sortedCategories = Object.entries(categoryCounts)
   </script>
 
   <script id="grants-data" type="application/json" set:html={JSON.stringify(searchResults)} />
-  <script id="category-colors" type="application/json" set:html={JSON.stringify(categoryColors)} />
+  <script id="category-colors" type="application/json" set:html={JSON.stringify(categoryColorMap)} />
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,60 @@
+/* ---------- Design tokens (bold redesign) ----------
+ * CSS variables exposed for component-level CSS that needs `var()` access.
+ * Tailwind utilities cover most styling; these enable inline styles and
+ * scoped <style> blocks (e.g. masthead rules, accent-tint backgrounds, the
+ * --cat-* category colors) to reference tokens by name.
+ */
+:root {
+  /* Neutrals */
+  --bg-page: #fafaf7;
+  --bg-card: #ffffff;
+  --bg-muted: #f6f5f0;
+  --bg-subtle: #f2f1ec;
+  --border-default: #e8e6e0;
+  --border-soft: #d0cec8;
+  --text-primary: #1a1918;
+  --text-body: #4a4840;
+  --text-secondary: #6a6860;
+  --text-muted: #7a7870;
+  --text-faint: #807e76;
+  --text-ghost: #908e86;
+
+  /* Accent and accent variants */
+  --accent: #c23b22;
+  --accent-bg: rgba(194, 59, 34, 0.08);
+  --accent-border: rgba(194, 59, 34, 0.12);
+  --accent-tint: rgba(194, 59, 34, 0.04);
+
+  /* Category colors — keyed to the live DB enum.
+   * AI-reclassification will add `january 6`, `political corruption`,
+   * `cryptocurrency`. Unknown keys fall back to --cat-fallback via the
+   * helper in src/lib/category-colors.ts. */
+  --cat-fraud: #8a6b1e;
+  --cat-drug-offense: #3a6a4a;
+  --cat-firearms: #c23b22;
+  --cat-face-act: #b8652a;
+  --cat-financial-crime: #2a6a7a;
+  --cat-violent-crime: #6a4b7a;
+  --cat-immigration: #7a6a3a;
+  --cat-other: #7a7870;
+  --cat-fallback: #7a7870;
+
+  /* Bold-scale serif sizes — homepage hero, number wall, masthead */
+  --text-display-xl: 84px; /* hero headline */
+  --text-display-lg: 64px; /* number-wall figures */
+  --text-display: 36px; /* pull-quote, masthead title */
+
+  /* Bold rules (masthead double-border pattern) */
+  --rule-emphasis: 2px solid var(--text-primary);
+  --rule-accent: 2px solid var(--accent);
+
+  /* Type families and layout primitives */
+  --serif: "DM Serif Display", Georgia, serif;
+  --sans: "DM Sans", system-ui, sans-serif;
+  --radius-card: 8px;
+  --radius-pill: 4px;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,7 @@ export default {
           DEFAULT: "#C23B22",
           bg: "rgba(194,59,34,0.08)",
           border: "rgba(194,59,34,0.12)",
+          tint: "rgba(194,59,34,0.04)",
         },
         border: {
           DEFAULT: "#E8E6E0",
@@ -41,6 +42,10 @@ export default {
         },
       },
       fontSize: {
+        // Bold-redesign display scale (homepage hero, number-wall figures, masthead pull-quotes)
+        "display-xl": ["84px", { lineHeight: "0.98", letterSpacing: "-0.025em" }],
+        "display-lg": ["64px", { lineHeight: "0.95", letterSpacing: "-0.025em" }],
+        display: ["36px", { lineHeight: "1.2", letterSpacing: "-0.015em" }],
         hero: ["52px", { lineHeight: "1.1" }],
         "page-title": ["36px", { lineHeight: "1.2" }],
         section: ["28px", { lineHeight: "1.3" }],


### PR DESCRIPTION
- Centralized category color mapping into a shared helper with a safe fallback, and applied it across president, search, and badge views for consistent UI behavior.
- Added Atom feed support via `/recent.xml`, including tests, then scoped the feed to the current administration and linked it from the recent page.
- Introduced shared formatting helpers for money, dates, and sentence lengths, with tests, and applied them to homepage and pardon detail displays.
- Added headline-action detection for large same-day category grant clusters so the homepage can show data-driven annotations.
- Redesigned the search experience with a simplified unified filter bar, clearer results header, and improved administration display data.
- Redesigned president pages to emphasize term context, rankings, key figures, and chronological navigation between administrations.
- Added previous/next pardon navigation within an administration on detail pages, using stable grant-date ordering.
- Created a new all-presidents comparison page covering modern administrations with sortable summary data across grant types and categories.
- Expanded analytics coverage with richer PostHog event metadata, exception capture, and documented tracked events in `.posthog-events.json`.
- Added Cloudflare Pages redirects for common guessed URLs and feed paths, and updated UI copy such as renaming “Clemency by” to “Pardons by”.