### PR TITLE
fix: update homepage hero copy to say pardons

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -147,11 +147,11 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
         <section class="hero-bold">
             <div class="eyebrow">{heroEyebrow}</div>
             <h1 class="hero-headline-bold">
-                <span class="quiet">{stats.totalGrants.toLocaleString()}</span> grants.
+                <span class="quiet">{stats.totalGrants.toLocaleString()}</span> pardons.
                 <br />
                 <span class="red">
                     {formatCompactMoney(stats.totalRestitutionAbandoned)}
-                </span> in restitution forgiven.
+                </span> forgiven.
                 <br />
                 {presidentCount} presidents.
             </h1>
@@ -442,7 +442,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                     not affiliated with the U.S. government.
                 </p>
                 <a href="/search" class="source-band-cta">
-                    Search all {stats.totalGrants.toLocaleString()} grants →
+                    Search all {stats.totalGrants.toLocaleString()} pardons →
                 </a>
             </div>
         </section>


### PR DESCRIPTION
Replace "grants" with "pardons" in the homepage hero and
search call to action to use the more accurate term for the
dataset.

Shorten the restitution line from "in restitution forgiven" to
"forgiven" to make the hero copy clearer and more concise while
preserving the meaning.