### PR TITLE
fix: enforce trailing slash route canonical URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,6 @@ import sitemap from "@astrojs/sitemap";
 // https://astro.build/config
 export default defineConfig({
   site: "https://pardonned.com",
+  trailingSlash: "always",
   integrations: [tailwind(), sitemap()],
 });

--- a/public/_redirects
+++ b/public/_redirects
@@ -4,20 +4,20 @@
 # These graceful 301s catch guessable wrong URLs that aren't real routes
 # but are plausible enough that visitors (or external links) might try them.
 # Real routes:
-#   /search                    — search page
-#   /pardon/details/<slug>     — single grant detail
-#   /all-presidents            — cross-administration table
-#   /recent                    — recent grants feed (HTML)
+#   /search/                   — search page
+#   /pardon/details/<slug>/    — single grant detail
+#   /all-presidents/           — cross-administration table
+#   /recent/                   — recent grants feed (HTML)
 #   /recent.xml                — Atom feed
 
 # Plural-form guesses for the search page
-/pardons         /search                       301
+/pardons         /search/                      301
 
 # Handoff-doc-implied detail URL → real detail URL
-/pardons/:slug   /pardon/details/:slug         301
+/pardons/:slug   /pardon/details/:slug/        301
 
 # "Presidents" plural → all-presidents page
-/presidents      /all-presidents               301
+/presidents      /all-presidents/              301
 
 # Common feed-discovery paths → Atom feed
 /feed            /recent.xml                   301

--- a/src/components/StatGrid.astro
+++ b/src/components/StatGrid.astro
@@ -51,7 +51,7 @@ const { stats, animated = false, footnote } = Astro.props;
         value={stats.totalYearsErased.toLocaleString()}
         footnote="In Years"
         noteText="Estimate — see note"
-        noteHref="/about#on-prison-time-reduced"
+        noteHref="/about/#on-prison-time-reduced"
         variant="default"
         animated={animated}
         animationDelay={animated ? 4 * 150 : 0}
@@ -60,7 +60,7 @@ const { stats, animated = false, footnote } = Astro.props;
         label="Restitution Abandoned"
         value={formatCurrency(stats.totalRestitutionAbandoned)}
         noteText="Estimate — see note"
-        noteHref="/about#on-fines-and-restitution-abandoned"
+        noteHref="/about/#on-fines-and-restitution-abandoned"
         variant="restitution"
         animated={animated}
         animationDelay={animated ? 5 * 150 : 0}
@@ -69,7 +69,7 @@ const { stats, animated = false, footnote } = Astro.props;
         label="Fines Abandoned"
         value={formatCurrency(stats.totalFinesAbandoned)}
         noteText="Estimate — see note"
-        noteHref="/about#on-fines-and-restitution-abandoned"
+        noteHref="/about/#on-fines-and-restitution-abandoned"
         variant="restitution"
         animated={animated}
         animationDelay={animated ? 6 * 150 : 0}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -6,10 +6,10 @@ export interface NavItem {
 
 export const mainNavigation: NavItem[] = [
   { label: "Home", href: "/" },
-  { label: "Search", href: "/search" },
-  { label: "Presidents", href: "/all-presidents" },
-  { label: "Recent", href: "/recent" },
-  { label: "About", href: "/about" },
+  { label: "Search", href: "/search/" },
+  { label: "Presidents", href: "/all-presidents/" },
+  { label: "Recent", href: "/recent/" },
+  { label: "About", href: "/about/" },
 ];
 
 // Helper to check if a nav item is active

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -196,7 +196,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                     </div>
                     <div class="nw-sub">
                         {newswire[0] ? (
-                            <a href="/recent" class="nw-latest-link">
+                            <a href="/recent/" class="nw-latest-link">
                                 {newswire[0].data.recipient_name}
                                 <span class="nw-latest-link-arrow" aria-hidden="true"> →</span>
                             </a>
@@ -224,7 +224,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                                 </span>
                             </span>
                         )}
-                        <a href="/recent" class="wire-view-all">
+                        <a href="/recent/" class="wire-view-all">
                             View all recent →
                         </a>
                     </div>
@@ -239,7 +239,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                         return (
                             <a
                                 class="wire-item"
-                                href={`/pardon/details/${d.slug}`}
+                                href={`/pardon/details/${d.slug}/`}
                                 data-grant-date={d.grant_date}
                                 data-grant-slug={d.slug}
                             >
@@ -294,7 +294,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                     return (
                         <a
                             class="cb-row"
-                            href={`/president/${admin.slug}`}
+                            href={`/president/${admin.slug}/`}
                             data-admin-slug={admin.slug}
                         >
                             <div class="cb-rank">{i + 1}</div>
@@ -371,7 +371,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                     return (
                         <a
                             class="lb-row"
-                            href={`/pardon/details/${d.slug}`}
+                            href={`/pardon/details/${d.slug}/`}
                             data-grant-slug={d.slug}
                             data-position={i + 1}
                             data-restitution={d.restitution ?? 0}
@@ -415,7 +415,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                     return (
                         <a
                             class="cat-row"
-                            href={`/search?categories=${encodeURIComponent(category)}`}
+                            href={`/search/?categories=${encodeURIComponent(category)}`}
                             data-category={category}
                         >
                             <div class="cat-num" style={`color:${color};`}>
@@ -446,7 +446,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                     grant page links to the original warrant PDF. Pardonned is
                     not affiliated with the U.S. government.
                 </p>
-                <a href="/search" class="source-band-cta">
+                <a href="/search/" class="source-band-cta">
                     Search all {stats.totalGrants.toLocaleString()} pardons →
                 </a>
             </div>
@@ -482,7 +482,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
 
         // view_all_recent_clicked — wire-head "View all recent →"
         document
-            .querySelector('a.wire-view-all[href="/recent"]')
+            .querySelector('a.wire-view-all[href="/recent/"]')
             ?.addEventListener("click", () => {
                 window.posthog?.capture("view_all_recent_clicked", {
                     source: "homepage_newswire",
@@ -491,7 +491,7 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
 
         // latest_grant_clicked — number-wall "Latest" cell sub-line link
         document
-            .querySelector('a.nw-latest-link[href="/recent"]')
+            .querySelector('a.nw-latest-link[href="/recent/"]')
             ?.addEventListener("click", () => {
                 window.posthog?.capture("latest_grant_clicked", {
                     source: "homepage_number_wall",

--- a/src/pages/pardon/details/[slug].astro
+++ b/src/pages/pardon/details/[slug].astro
@@ -251,7 +251,7 @@ const ogImagePath = `/og/${data.slug}.png`;
     <main class="detail-bold">
         <!-- Breadcrumb -->
         <div class="db-crumb">
-            <a href="/search">Search</a>
+            <a href="/search/">Search</a>
             <span class="db-crumb-sep">/</span>
             <span class="db-crumb-here">{data.recipient_name}</span>
         </div>
@@ -431,7 +431,7 @@ const ogImagePath = `/og/${data.slug}.png`;
             <div class="db-footer-cell db-footer-prev">
                 {older ? (
                     <a
-                        href={`/pardon/details/${older.slug}`}
+                        href={`/pardon/details/${older.slug}/`}
                         class="db-foot-link"
                         data-direction="older"
                         data-to-slug={older.slug}
@@ -453,7 +453,7 @@ const ogImagePath = `/og/${data.slug}.png`;
             </div>
             <div class="db-footer-cell db-footer-back">
                 <a
-                    href={`/president/${data.administration_slug}`}
+                    href={`/president/${data.administration_slug}/`}
                     class="db-back-link"
                 >
                     Back to {adminDisplay}
@@ -462,7 +462,7 @@ const ogImagePath = `/og/${data.slug}.png`;
             <div class="db-footer-cell db-footer-next">
                 {newer ? (
                     <a
-                        href={`/pardon/details/${newer.slug}`}
+                        href={`/pardon/details/${newer.slug}/`}
                         class="db-foot-link db-foot-link-right"
                         data-direction="newer"
                         data-to-slug={newer.slug}

--- a/src/pages/president/[slug].astro
+++ b/src/pages/president/[slug].astro
@@ -138,7 +138,7 @@ const timelineEntries = sortedDates.map((date, i) => {
         <div class="pp-crumb">
             <a href="/">Home</a>
             <span class="pp-crumb-sep">/</span>
-            <a href="/all-presidents">Presidents</a>
+            <a href="/all-presidents/">Presidents</a>
             <span class="pp-crumb-sep">/</span>
             <span class="pp-crumb-here">{presidentName}</span>
         </div>
@@ -206,7 +206,7 @@ const timelineEntries = sortedDates.map((date, i) => {
                         return (
                             <a
                                 class="pp-cat-row"
-                                href={`/search?president=${admin.slug}&category=${encodeURIComponent(row.key)}`}
+                                href={`/search/?president=${admin.slug}&category=${encodeURIComponent(row.key)}`}
                                 data-category={row.key}
                             >
                                 <div class="pp-cat-nm">
@@ -231,7 +231,7 @@ const timelineEntries = sortedDates.map((date, i) => {
 
                 <div class="pp-timeline-cta">
                     <a
-                        href={`/search?president=${admin.slug}`}
+                        href={`/search/?president=${admin.slug}`}
                         class="pp-timeline-cta-link"
                         data-search-cta
                     >
@@ -246,7 +246,7 @@ const timelineEntries = sortedDates.map((date, i) => {
             <div class="pp-footer-cell pp-footer-prev">
                 {older ? (
                     <a
-                        href={`/president/${older.slug}`}
+                        href={`/president/${older.slug}/`}
                         class="pp-foot-link"
                         data-direction="older"
                         data-to-slug={older.slug}
@@ -263,14 +263,14 @@ const timelineEntries = sortedDates.map((date, i) => {
                 )}
             </div>
             <div class="pp-footer-cell pp-footer-back">
-                <a href="/all-presidents" class="pp-back-link">
+                <a href="/all-presidents/" class="pp-back-link">
                     View all administrations →
                 </a>
             </div>
             <div class="pp-footer-cell pp-footer-next">
                 {newer ? (
                     <a
-                        href={`/president/${newer.slug}`}
+                        href={`/president/${newer.slug}/`}
                         class="pp-foot-link pp-foot-link-right"
                         data-direction="newer"
                         data-to-slug={newer.slug}

--- a/src/pages/recent.astro
+++ b/src/pages/recent.astro
@@ -124,7 +124,7 @@ function dayLabel(isoDate: string): string {
                 Every federal pardon and commutation issued during the
                 current administration, newest first. Each entry links to
                 the original DOJ warrant. For
-                <a href="/search" class="rb-deck-link">previous administrations</a>
+                <a href="/search/" class="rb-deck-link">previous administrations</a>
                 or filtered queries, use search. Subscribe via
                 <a href="/recent.xml" class="rb-deck-link">Atom feed</a>.
             </p>
@@ -207,7 +207,7 @@ function dayLabel(isoDate: string): string {
                                 return (
                                     <a
                                         class="rb-entry"
-                                        href={`/pardon/details/${d.slug}`}
+                                        href={`/pardon/details/${d.slug}/`}
                                         data-grant-slug={d.slug}
                                         data-grant-date={d.grant_date}
                                     >
@@ -257,7 +257,7 @@ function dayLabel(isoDate: string): string {
                                         </div>
                                         <div class="rb-pres">
                                             <a
-                                                href={`/president/${d.administration_slug}`}
+                                                href={`/president/${d.administration_slug}/`}
                                                 class="rb-pres-link"
                                                 onclick="event.stopPropagation();"
                                                 data-admin-slug={d.administration_slug}
@@ -310,7 +310,7 @@ function dayLabel(isoDate: string): string {
                     records, including all 3,205 grants since 1993, use
                     search with administration and date filters.
                 </p>
-                <a href="/search" class="rb-feed-end-cta">
+                <a href="/search/" class="rb-feed-end-cta">
                     Open full search →
                 </a>
             </div>


### PR DESCRIPTION
Enable trailing slash routing in Astro and update internal links to
use canonical slash-terminated paths.

Align redirects with the canonical route format for search, pardon
details, presidents, and recent pages so guessed URLs resolve to the
correct destination consistently.

Prevent duplicate URL variants and reduce routing ambiguity across
navigation, search links, pagination links, and feed discovery paths.