### PR TITLE
fix: never frame preemptive pardons as convictions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Canonical state vocabulary: `needs-info`, `ready-for-agent`, `ready-for-human`, 
 
 ### Domain docs
 
-Single-context: `CONTEXT.md` (domain vocabulary) and `docs/adr/` (ADRs 0001–0005) at the repo root — read the ones touching your area before working. See `docs/agents/domain.md`.
+Single-context: `CONTEXT.md` (domain vocabulary) and `docs/adr/` (ADRs 0001–0006) at the repo root — read the ones touching your area before working. See `docs/agents/domain.md`.
 
 ## Code Style
 
@@ -66,6 +66,7 @@ The loader joins `pardons` against `administrations` and exposes `administration
 - `src/db/schema.ts` — Drizzle schema for `administrations` and `pardons` tables
 - `src/loaders/pardon-details.ts` — content collection loader (SQLite query + join)
 - `src/content.config.ts` — Astro content collection config
+- `src/lib/pardon-clause.ts` — clause predicates for `offense`/`district`/`original_sentence`; every surface rendering these fields must go through it (ADR-0006)
 - `src/lib/pardon-stats.ts` — `computeStats`, `filterByAdministration`, etc.
 - `src/lib/president-names.ts` — display-name formatter + collection index builder
 - `src/lib/slugify.ts` — URL slug generator (checks override map, caps at 60 chars with sha1 suffix fallback)
@@ -90,6 +91,7 @@ pnpm scrape              # Repopulate from DOJ sources (slow, 5-10 min)
 
 ## Gotchas
 
+- **Never render `offense`, `district`, or `original_sentence` raw**: ~6 records are preemptive pardons (no conviction — Fauci, Milley, Tina Peters, Hunter Biden, two group clemencies) whose fields carry scope legalese or scraper sentinels (`"N/A"`, `"Download PDF Clemency Warrant"`). Rendering them raw states a false conviction. Always go through the predicates in `src/lib/pardon-clause.ts` — see ADR-0006 and CONTEXT.md ("Preemptive pardon"). Related: em-dash in the detail-page aside means *unknown*; *inapplicable* values (scope-mode records) omit the row entirely.
 - **U+00A0 non-breaking spaces in `recipient_name`**: scraped from `&nbsp;` in DOJ HTML. ~14 pardon records carry NBSPs somewhere in the name (e.g. "Robin Marie Davis", "Terrance Cox", the Biden family group pardon). Any string comparison against `recipient_name` must account for this — three records have slug-override keys using `\u00A0` explicitly in `src/lib/pardon-slug-overrides.ts`, and the /search name matcher normalizes NBSPs before comparing (`normalizeName` in `src/pages/search.astro`).
 - **Long `recipient_name` values need manual slug overrides**: ~21 records have names >50 chars, including one 374-char group clemency (the January 6 Select Committee). If the scraper discovers a new long name, `pnpm build` crashes with `ENAMETOOLONG` on the OG image step — add the new record to `src/lib/pardon-slug-overrides.ts`.
 - **Slug collisions cause ~30 pardons to collapse**: `getStaticPaths` deduplicates on the slug param, so two different pardons with the same slugified name produce only one HTML page. Pre-existing issue tracked in #13; don't be surprised when `2149 rows read` produces only `2119 pages built`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,8 @@ A nicer view of US presidential pardons. The DOJ Office of the Pardon Attorney's
 
 > **Scope note:** the project does not currently model amnesties or reprieves — only pardons (full) and commutations, because that's how DOJ exposes the underlying warrant data.
 
+**Preemptive pardon** — a Pardon (full) granted where **no conviction exists**: the warrant covers offenses the recipient "may have committed" over a stated period, rather than a specific adjudicated offense (e.g. Anthony Fauci, Mark Milley, Tina Peters, the Biden family group, the January 6 Select Committee). **Not a schema field** — there is no `clemency_type` value or flag column; the condition is derived at presentation time from the scope legalese in the warrant text (detected by `PARDON_SCOPE_LEGALESE` in `src/lib`). DOJ's phrasing varies — "For any offenses against the United States…", "For those offenses she has or may have committed… related to election integrity…" (no "against the United States" clause), sometimes wrapped in curly quotes — so detection anchors on the shared skeleton `For any|those … offenses … committed`, not any one phrasing. Pages and feeds must never frame these records as convictions — no "convicted of," no counts, no sentence/district/fine display. A record whose offense field is a scraper sentinel gets the same no-conviction-framing treatment; the site does not currently distinguish "never charged" from "data unavailable."
+
 **Pardon record** — one row in the `pardons` table. Identified by the compound key `(administration, recipient_name, grant_date, clemency_type)`. Counts and statistics on the site are over Pardon records, not over distinct humans.
 
 **Recipient** — the human(s) named in a Pardon record's `recipient_name`. **Not a first-class entity in the schema today.** There is no recipients table and no person-level deduplication. Group clemencies (e.g. Biden family, January 6 Select Committee) are stored as a single Pardon record with multiple humans implicit in the name string. Person-level questions ("how many distinct people did this president pardon?") are not answerable from the current model — see [issue #51](https://github.com/vidluther/pardonned/issues/51) for the planned extraction.
@@ -39,6 +41,13 @@ A closed taxonomy on each Pardon record: `violent crime`, `fraud`, `drug offense
 The taxonomy is **editorial, not legal**. Categories exist when they help surface patterns this project cares about. `FACE act` is a peer of broader categories (rather than nested under "violent crime" or "other") because the Trump-2 pardons of FACE Act defendants are a focal pattern. **Don't "normalize" or flatten the taxonomy without raising it as an editorial change first.**
 
 Classification today is regex-based via `categorizeOffense()` in `src/lib/parsers/categorize.ts`. **An LLM-backed enhancement is planned in [issue #26](https://github.com/vidluther/pardonned/issues/26)** — the categories themselves stay; only the classifier gets smarter, with a local cache to keep build cost flat. Don't hand-tune the regex map or attempt to swap classifiers ahead of #26 — coordinate with that work.
+
+**This taxonomy answers exactly one question: what kind of crime.** Two neighboring axes are deliberately kept out of it and must not be folded in:
+
+1. **Record shape** — whether a conviction exists at all. Derived from warrant text at presentation time (see **Preemptive pardon**), never a category value.
+2. **Motive / notability** — why a pardon matters (e.g. alleged political retribution). That is editorial interpretation and belongs in Pardon Context ([ADR-0002](docs/adr/0002-pardon-context-as-editorial-layer.md), [issue #52](https://github.com/vidluther/pardonned/issues/52)), authored by a human — never asserted by a classifier.
+
+Do not add values like `preemptive` or `political retribution` to this enum — each collapses an orthogonal axis into it and forces false choices (a Fauci-type record is simultaneously `other`, preemptive, and allegedly retribution-motivated).
 
 ## Pardon Context (planned, not yet in the schema)
 

--- a/docs/adr/0003-serp-presentation-policy-in-detail-seo.md
+++ b/docs/adr/0003-serp-presentation-policy-in-detail-seo.md
@@ -1,6 +1,6 @@
 # ADR-0003 — SERP presentation policy lives in the detail-seo module
 
-**Status:** Accepted. Governs the PR #64 fix round (review findings from the xhigh review, 2026-07-17).
+**Status:** Accepted. Governs the PR #64 fix round (review findings from the xhigh review, 2026-07-17). **Amended by [ADR-0006](0006-conviction-vs-scope-presentation.md) (2026-07-18):** the clause guards described below as module-private (sentinels, legalese regex, `cleanClause`/`realClause`) now live in `src/lib/pardon-clause.ts`, shared by every rendering surface, and the legalese pattern is generalized beyond `/^for any offenses/i` to cover DOJ's phrasing variants (Tina Peters). The SERP policy itself is unchanged.
 
 ## Context
 

--- a/docs/adr/0006-conviction-vs-scope-presentation.md
+++ b/docs/adr/0006-conviction-vs-scope-presentation.md
@@ -1,0 +1,38 @@
+# ADR-0006 — Conviction-shaped vs scope-shaped rendering via shared clause predicates
+
+**Status:** Accepted (2026-07-18). Amends ADR-0003 (the clause guards it described as private to `detail-seo.ts` are now shared and generalized).
+
+## Context
+
+ADR-0003 made SERP strings safe against preemptive-pardon legalese and scraper sentinels, but the guards were private to `detail-seo.ts` and covered only SERP strings. The rendered pages still framed preemptive pardons (CONTEXT.md, "Preemptive pardon") as convictions:
+
+- Fauci's detail page said "The conviction · 3 federal counts" — comma-splitting the warrant's scope legalese into fake counts — and rendered `district = "N/A"` literally.
+- The atom feed emitted `Offense: Download PDF Clemency Warrant` (Hunter Biden's sentinel) and labeled scope legalese as an "Offense:".
+- Search rows showed `· N/A` districts and legalese as a "sentence"; home/recent listings leaked sentinels.
+
+Six records are affected today (Fauci, Milley, Tina Peters, Hunter Biden, the Biden family group, the January 6 Select Committee) — the highest-traffic, highest-scrutiny pages on the site. During the fix round, Tina Peters proved DOJ's legalese phrasing varies: hers is wrapped in curly quotes and omits the "against the United States" clause entirely, so any single-phrasing regex will miss the next variant.
+
+An alternative path was considered and rejected: classify record shape via the planned AI offense classifier (#26/#28), or store it as a schema field/category value. CONTEXT.md ("Offense category" three-axes rule) records why — shape, crime type, and motive are orthogonal axes, and shape is deterministically derivable from the warrant text.
+
+## Decision
+
+1. **Clause predicates live in `src/lib/pardon-clause.ts` — the single source of truth.** Every surface that renders `offense`, `district`, or `original_sentence` must go through it: detail page, home newswire + leaderboard, recent, search, atom feed, and `detail-seo.ts`. No template touches these fields raw.
+2. **A record is conviction-shaped iff `realClause(offense, OFFENSE_SENTINELS)` (or its display twin `proseClause`) is non-null.** Otherwise it renders in **scope mode**. Derived at build time, never stored. Preemptive pardons and broken-data records get the same neutral no-conviction-framing treatment — distinguishing "never charged" from "data unavailable" is deferred editorial work (Pardon Context, ADR-0002).
+3. **Scope-mode rendering on the detail page:** no conviction framing anywhere — no counts, no "Convicted of", no district under the `<h1>`. The warrant's scope prose renders as a pull-quote under "The pardon / What this pardon covers." (falling back to `original_sentence` when the offense field is a sentinel — Hunter Biden). The District row and the entire "Sentencing & impact" block are omitted.
+4. **Em-dash means "unknown"; omission means "inapplicable."** Conviction records with missing data keep em-dash rows. Scope-mode records omit rows/blocks entirely — there was no case, so the values aren't unknown, they don't exist.
+5. **Legalese detection anchors on the shared skeleton, not any one phrasing:** `For any|those … offenses … committed`, tested against quote-stripped text (`displayClause` strips wrapping straight/curly double quotes). Validated against every clause value in the database (6,452 values): exactly the 6 known legalese texts match, zero false positives. Tests pin all known phrasing variants as fixtures.
+6. **Listing surfaces still display scope legalese** — it is informative and self-describing ("…may have committed…") — but never display sentinels, and the atom feed never labels legalese as "Offense:".
+7. **Conviction-page copy:** the offense list leads with a single "Convicted of:" heading — the former "THE CONVICTION" eyebrow + "N federal counts." pairing both double-labeled the section and asserted a count the data doesn't support (the numbering comes from comma-splitting DOJ's string, not charging documents).
+
+## Consequences
+
+- **Pro:** the page, listings, feed, and SERP strings share one predicate and can never disagree about whether a conviction exists.
+- **Pro:** the next preemptive pardon (or scraper regression) is handled the day it's scraped — no hardcoded name list to maintain.
+- **Con:** the skeleton regex is a heuristic; a hypothetical real offense reading "For any … offenses … committed" would false-positive into scope mode. Accepted: validated against the full dataset, and the failure mode (under-claiming a conviction) is the safe direction — this site must never state a false conviction, per ADR-0003.
+- **Con:** presentation-layer guards continue to paper over scraper defects (same trade-off as ADR-0003; upstream scraper fixes remain follow-up work).
+
+## Alternatives considered
+
+- **Store shape in the schema (flag column or `offense_category` value).** Rejected: collapses orthogonal axes into one column (CONTEXT.md three-axes rule) and duplicates information derivable from the text.
+- **AI-classify shape alongside #26/#28.** Rejected: the deterministic signal already exists and is free; gating a live falsehood fix on a classifier project delays it for no gain.
+- **Hardcoded list of the six slugs.** Rejected: the Tina Peters variant proves phrasing drifts; the next one would slip through as a fake conviction.

--- a/src/lib/__tests__/atom-feed.test.ts
+++ b/src/lib/__tests__/atom-feed.test.ts
@@ -44,8 +44,12 @@ describe("buildAtomFeed", () => {
     expect(xml).toContain("</feed>");
     expect(xml).toContain("<id>https://pardonned.com/recent.xml</id>");
     expect(xml).toContain("<title>Pardonned — Recent Clemency Grants</title>");
-    expect(xml).toContain('<link rel="self" type="application/atom+xml" href="https://pardonned.com/recent.xml"/>');
-    expect(xml).toContain('<link rel="alternate" type="text/html" href="https://pardonned.com/recent"/>');
+    expect(xml).toContain(
+      '<link rel="self" type="application/atom+xml" href="https://pardonned.com/recent.xml"/>',
+    );
+    expect(xml).toContain(
+      '<link rel="alternate" type="text/html" href="https://pardonned.com/recent"/>',
+    );
   });
 
   it("sorts entries by grant_date desc and applies the default limit of 50", () => {
@@ -106,11 +110,16 @@ describe("buildAtomFeed", () => {
 
   it("links each entry to its detail page using the slug", () => {
     const xml = buildAtomFeed([makeEntry({ slug: "paul-manafort" })], baseOptions);
-    expect(xml).toContain('<link rel="alternate" type="text/html" href="https://pardonned.com/pardon/details/paul-manafort"/>');
+    expect(xml).toContain(
+      '<link rel="alternate" type="text/html" href="https://pardonned.com/pardon/details/paul-manafort"/>',
+    );
   });
 
   it("uses a stable tag: URI for entry id", () => {
-    const xml = buildAtomFeed([makeEntry({ slug: "paul-manafort", grant_date: "2020-12-23" })], baseOptions);
+    const xml = buildAtomFeed(
+      [makeEntry({ slug: "paul-manafort", grant_date: "2020-12-23" })],
+      baseOptions,
+    );
     expect(xml).toContain("<id>tag:pardonned.com,2020-12-23:pardon-paul-manafort</id>");
   });
 
@@ -199,8 +208,69 @@ describe("buildAtomFeed", () => {
     );
   });
 
+  it("renders scope prose un-labeled — never 'Offense:' — for preemptive pardons", () => {
+    const scope =
+      "For any offenses against the United States which he may have committed or taken part in during the period from January 1, 2014, through the date of this pardon.";
+    const xml = buildAtomFeed(
+      [
+        makeEntry({
+          recipient_name: "Anthony S. Fauci",
+          offense: scope,
+          district: "N/A",
+          grant_date: "2025-01-20",
+          president_name: "Joseph R. Biden",
+        }),
+      ],
+      baseOptions,
+    );
+    expect(xml).not.toContain("Offense:");
+    expect(xml).toContain("which he may have committed");
+    // No doubled trailing period after the scope prose
+    expect(xml).not.toContain("pardon..");
+  });
+
+  it("falls back to original_sentence scope prose when the offense field is a scraper sentinel", () => {
+    const xml = buildAtomFeed(
+      [
+        makeEntry({
+          recipient_name: "Robert Hunter Biden",
+          offense: "Download PDF Clemency Warrant",
+          original_sentence:
+            "For those offenses against the United States which he has committed or may have committed or taken part in during the period from January 1, 2014 through December 1, 2024.",
+        }),
+      ],
+      baseOptions,
+    );
+    expect(xml).not.toContain("Offense:");
+    expect(xml).not.toContain("Download PDF Clemency Warrant");
+    expect(xml).toContain("For those offenses against the United States");
+  });
+
+  it("omits the offense clause entirely when only sentinels are available", () => {
+    const xml = buildAtomFeed(
+      [
+        makeEntry({
+          recipient_name: "Test Person",
+          clemency_type: "pardon",
+          offense: "Download PDF Clemency Warrant",
+          original_sentence: "N/A",
+          grant_date: "2024-12-01",
+          president_name: "Joseph R. Biden",
+        }),
+      ],
+      baseOptions,
+    );
+    expect(xml).toContain(
+      "Pardon granted to Test Person by Joseph R. Biden on 2024-12-01.</summary>",
+    );
+    expect(xml).not.toContain("Offense:");
+  });
+
   it("uses the configured siteUrl for self-link, alternate-link, and feed id", () => {
-    const xml = buildAtomFeed([makeEntry()], { ...baseOptions, siteUrl: "https://staging.pardonned.com" });
+    const xml = buildAtomFeed([makeEntry()], {
+      ...baseOptions,
+      siteUrl: "https://staging.pardonned.com",
+    });
     expect(xml).toContain("<id>https://staging.pardonned.com/recent.xml</id>");
     expect(xml).toContain('href="https://staging.pardonned.com/recent.xml"');
     expect(xml).toContain('href="https://staging.pardonned.com/recent"');

--- a/src/lib/__tests__/pardon-clause.test.ts
+++ b/src/lib/__tests__/pardon-clause.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanClause,
+  displayClause,
+  normalizeSpaces,
+  OFFENSE_SENTINELS,
+  proseClause,
+  realClause,
+  scopeClause,
+} from "../pardon-clause";
+
+// Real scope legalese from the data (abbreviated): the three phrasings DOJ
+// warrants use — "For any offenses…", "For any nonviolent offenses…" (Biden
+// family), "For those offenses…" (Hunter Biden's original_sentence).
+const FAUCI_SCOPE =
+  "For any offenses against the United States which he may have committed or taken part in during the period from January 1, 2014, through the date of this pardon arising from or in any manner related to his service as Director of the National Institute of Allergy and Infectious Diseases, as a member of the White House Coronavirus Task Force or the White House COVID-19 Response Team, or as Chief Medical Advisor to the President.";
+const BIDEN_FAMILY_SCOPE =
+  "For any nonviolent offenses against the United States which they may have committed or taken part in during the period from January 1, 2014, through the date of this pardon.";
+const HUNTER_SCOPE =
+  "For those offenses against the United States which he has committed or may have committed or taken part in during the period from January 1, 2014 through December 1, 2024.";
+// Tina Peters: DOJ wraps the text in curly quotes and drops the "against the
+// United States" clause entirely — the variant that motivated anchoring the
+// regex on the shared skeleton instead of any one phrasing.
+const TINA_SCOPE_QUOTED =
+  "“For those offenses she has or may have committed or taken part in related to election integrity and security during the period from January 1, 2020 through December 31, 2021”";
+const TINA_SCOPE_UNQUOTED =
+  "For those offenses she has or may have committed or taken part in related to election integrity and security during the period from January 1, 2020 through December 31, 2021";
+// Milley: a long parenthetical between "offenses" and "committed".
+const MILLEY_SCOPE =
+  "For any offenses against the United States, including but not limited to any offenses under the United States Code or the Uniform Code of Military Justice, which he may have committed or taken part in during the period from January 1, 2014, through the date of this pardon.";
+
+const REAL_OFFENSE =
+  "Conspiracy to manufacture and distribute 500 grams or more of methamphetamine mixture following a felony drug conviction";
+const OFFENSE_GARBAGE = "Download PDF Clemency Warrant";
+
+describe("normalizeSpaces", () => {
+  it("replaces NBSPs with regular spaces", () => {
+    expect(normalizeSpaces("Robin\u00A0Marie\u00A0Davis")).toBe("Robin Marie Davis");
+  });
+});
+
+describe("displayClause", () => {
+  it("returns null for empty and missing values", () => {
+    expect(displayClause(null)).toBeNull();
+    expect(displayClause(undefined)).toBeNull();
+    expect(displayClause("")).toBeNull();
+    expect(displayClause("   ")).toBeNull();
+  });
+
+  it('treats "N/A" as a sentinel in every field', () => {
+    expect(displayClause("N/A")).toBeNull();
+  });
+
+  it("drops field-specific sentinels only when passed", () => {
+    expect(displayClause(OFFENSE_GARBAGE, OFFENSE_SENTINELS)).toBeNull();
+    expect(displayClause(OFFENSE_GARBAGE)).toBe(OFFENSE_GARBAGE);
+  });
+
+  it("normalizes NBSPs and trims, keeping punctuation", () => {
+    expect(displayClause("  Northern District of Iowa. ")).toBe("Northern District of Iowa.");
+  });
+
+  it("keeps scope legalese — it is informative on listing surfaces", () => {
+    expect(displayClause(FAUCI_SCOPE)).toBe(FAUCI_SCOPE);
+  });
+
+  it("strips wrapping curly quotes (Tina Peters)", () => {
+    expect(displayClause(TINA_SCOPE_QUOTED)).toBe(TINA_SCOPE_UNQUOTED);
+  });
+});
+
+describe("cleanClause", () => {
+  it("strips one trailing period for sentence composition", () => {
+    expect(cleanClause("Northern District of Iowa.")).toBe("Northern District of Iowa");
+  });
+
+  it("still nulls sentinels", () => {
+    expect(cleanClause("N/A")).toBeNull();
+  });
+});
+
+describe("realClause", () => {
+  it("rejects every scope-legalese phrasing in the data", () => {
+    expect(realClause(FAUCI_SCOPE)).toBeNull();
+    expect(realClause(BIDEN_FAMILY_SCOPE)).toBeNull();
+    expect(realClause(HUNTER_SCOPE)).toBeNull();
+    expect(realClause(TINA_SCOPE_QUOTED)).toBeNull();
+    expect(realClause(MILLEY_SCOPE)).toBeNull();
+  });
+
+  it("rejects sentinels", () => {
+    expect(realClause("N/A")).toBeNull();
+    expect(realClause(OFFENSE_GARBAGE, OFFENSE_SENTINELS)).toBeNull();
+  });
+
+  it("passes real conviction content through, period-stripped", () => {
+    expect(realClause(REAL_OFFENSE)).toBe(REAL_OFFENSE);
+    expect(realClause(`${REAL_OFFENSE}.`)).toBe(REAL_OFFENSE);
+  });
+});
+
+describe("proseClause", () => {
+  it("keeps punctuation on real content", () => {
+    expect(proseClause(`${REAL_OFFENSE}.`)).toBe(`${REAL_OFFENSE}.`);
+  });
+
+  it("has identical nullity to realClause across all input shapes", () => {
+    const inputs = [
+      null,
+      undefined,
+      "",
+      "N/A",
+      OFFENSE_GARBAGE,
+      FAUCI_SCOPE,
+      BIDEN_FAMILY_SCOPE,
+      HUNTER_SCOPE,
+      TINA_SCOPE_QUOTED,
+      MILLEY_SCOPE,
+      REAL_OFFENSE,
+      `${REAL_OFFENSE}.`,
+    ];
+    for (const input of inputs) {
+      expect(proseClause(input, OFFENSE_SENTINELS) === null).toBe(
+        realClause(input, OFFENSE_SENTINELS) === null,
+      );
+    }
+  });
+});
+
+describe("scopeClause", () => {
+  it("returns the legalese itself, display-quality", () => {
+    expect(scopeClause(FAUCI_SCOPE)).toBe(FAUCI_SCOPE);
+    expect(scopeClause(BIDEN_FAMILY_SCOPE)).toBe(BIDEN_FAMILY_SCOPE);
+    expect(scopeClause(HUNTER_SCOPE)).toBe(HUNTER_SCOPE);
+    expect(scopeClause(MILLEY_SCOPE)).toBe(MILLEY_SCOPE);
+  });
+
+  it("unwraps quoted legalese for display (Tina Peters)", () => {
+    expect(scopeClause(TINA_SCOPE_QUOTED)).toBe(TINA_SCOPE_UNQUOTED);
+  });
+
+  it("returns null for real offenses and sentinels", () => {
+    expect(scopeClause(REAL_OFFENSE)).toBeNull();
+    expect(scopeClause("N/A")).toBeNull();
+    expect(scopeClause(null)).toBeNull();
+  });
+});

--- a/src/lib/atom-feed.ts
+++ b/src/lib/atom-feed.ts
@@ -1,4 +1,5 @@
 import type { PardonDetail } from "../loaders/pardon-details";
+import { OFFENSE_SENTINELS, realClause, scopeClause } from "./pardon-clause";
 import { formatAdministrationDisplayName } from "./president-names";
 
 /**
@@ -90,7 +91,17 @@ export function buildAtomFeed(entries: AtomEntry[], options: AtomFeedOptions): s
         isOnlyTerm: termsPerPresident.get(d.president_name)!.size === 1,
       });
       const clemencyLabel = d.clemency_type === "pardon" ? "Pardon" : "Commutation";
-      const summary = `${clemencyLabel} granted to ${d.recipient_name} by ${adminDisplay} on ${d.grant_date}. Offense: ${d.offense}.`;
+      // "Offense:" only when a real conviction exists. Preemptive pardons get
+      // the warrant's own scope prose un-labeled (it self-describes); scraper
+      // sentinels get nothing (see pardon-clause.ts).
+      const offense = realClause(d.offense, OFFENSE_SENTINELS);
+      const scope = scopeClause(d.offense) ?? scopeClause(d.original_sentence);
+      const base = `${clemencyLabel} granted to ${d.recipient_name} by ${adminDisplay} on ${d.grant_date}.`;
+      const summary = offense
+        ? `${base} Offense: ${offense}.`
+        : scope
+          ? `${base} ${scope}${scope.endsWith(".") ? "" : "."}`
+          : base;
 
       return `  <entry>
     <id>tag:pardonned.com,${d.grant_date}:pardon-${escapeXml(d.slug)}</id>

--- a/src/lib/detail-seo.ts
+++ b/src/lib/detail-seo.ts
@@ -1,6 +1,7 @@
 import { formatCompactMoney, formatGrantDateLong } from "./format";
 import { serializeJsonLd, truncateText } from "./seo";
 import { siteConfig } from "../config/site";
+import { cleanClause, normalizeSpaces, OFFENSE_SENTINELS, realClause } from "./pardon-clause";
 
 /** SERP snippet budget — Google truncates descriptions around this length. */
 const MAX_DESCRIPTION_LENGTH = 155;
@@ -20,7 +21,10 @@ const MAX_TITLE_LENGTH = 110;
  * "For any offenses…" legalese with no conviction; scraper sentinels leak
  * through (`district = "N/A"`, `offense = "Download PDF Clemency Warrant"`);
  * abbreviated districts end in `.`; group clemencies have 300+ char names.
- * The guards below keep the page from ever stating a false conviction.
+ * The clause guards live in `pardon-clause.ts` (shared with the page
+ * templates, so SERP strings and rendered pages can never disagree about
+ * whether a conviction exists); the guards here keep the SERP strings from
+ * ever stating a false conviction.
  */
 export interface DetailSeoInput {
   slug: string;
@@ -64,52 +68,6 @@ const CLEMENCY_LABELS: Record<string, string> = {
 
 function clemencyLabel(type: string): string {
   return CLEMENCY_LABELS[type] ?? type.charAt(0).toUpperCase() + type.slice(1);
-}
-
-/**
- * DOJ HTML uses &nbsp; inside some recipient names (repo gotcha). SERP-facing
- * strings must show regular spaces; slug/override lookups elsewhere must NOT
- * use this (they are byte-exact).
- */
-function normalizeSpaces(s: string): string {
-  return s.replace(/\u00A0/g, " ");
-}
-
-// "N/A" is a scraper placeholder in every clause field (district, offense,
-// original_sentence) — never a real value.
-const NA_SENTINEL = "N/A";
-// Field-specific sentinels beyond "N/A".
-const OFFENSE_SENTINELS = new Set(["Download PDF Clemency Warrant"]);
-// Preemptive-pardon scope legalese ("For any/those/nonviolent offenses against
-// the United States…") describes what the pardon covers — not a conviction or a
-// sentence. It leaks into both the offense and original_sentence fields.
-const PARDON_SCOPE_LEGALESE = /^for .{0,30}offenses against the United States/i;
-
-/**
- * Normalize a scraped clause value: NBSP→space, trim, drop trailing period
- * (so the module can add its own punctuation without doubling), and treat
- * empty/sentinel values as missing. "N/A" is always a sentinel; pass extras
- * for field-specific junk.
- */
-function cleanClause(
-  value: string | null | undefined,
-  extraSentinels?: Set<string>,
-): string | null {
-  if (!value) return null;
-  const trimmed = normalizeSpaces(value).trim();
-  if (!trimmed || trimmed === NA_SENTINEL || extraSentinels?.has(trimmed)) return null;
-  return trimmed.replace(/\.$/, "");
-}
-
-/**
- * A clause value that is real content — not a sentinel, not pardon-scope
- * legalese (which would falsely read as a conviction or a sentence). Used for
- * both the offense and original_sentence fields.
- */
-function realClause(value: string | null | undefined, extraSentinels?: Set<string>): string | null {
-  const cleaned = cleanClause(value, extraSentinels);
-  if (!cleaned || PARDON_SCOPE_LEGALESE.test(cleaned)) return null;
-  return cleaned;
 }
 
 // A trailing corporate designator: "… LLC", "… , Inc.", "… Limited".

--- a/src/lib/pardon-clause.ts
+++ b/src/lib/pardon-clause.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared predicates for scraped pardon clause fields (`offense`, `district`,
+ * `original_sentence`).
+ *
+ * Pardon record fields cannot be trusted raw: preemptive pardons carry
+ * "For any offenses…" scope legalese with no conviction; scraper sentinels
+ * leak through (`district = "N/A"`, `offense = "Download PDF Clemency
+ * Warrant"`); DOJ HTML plants NBSPs inside values. Every surface that renders
+ * these fields — detail page, listings, search, atom feed, SERP strings —
+ * must go through this module so the site never states a false conviction
+ * and never disagrees with itself about whether one exists (CONTEXT.md,
+ * "Preemptive pardon").
+ *
+ * The functions form a ladder; each rung filters more than the last:
+ *
+ * - `displayClause` — sentinel-free display text, punctuation kept.
+ * - `cleanClause` — `displayClause` minus the trailing period, for composing
+ *   sentences ("Convicted of X in the Y.") without doubled punctuation.
+ * - `proseClause` / `realClause` — additionally reject scope legalese; null
+ *   means "no real conviction content". The two differ only in trailing-period
+ *   handling (`proseClause` keeps it for display, `realClause` strips it for
+ *   sentence composition) — their nullity is always identical, so either one
+ *   is a valid "is this record conviction-shaped?" test.
+ * - `scopeClause` — the inverse: the text only when it IS scope legalese,
+ *   for rendering a preemptive pardon's coverage as prose.
+ */
+
+// "N/A" is a scraper placeholder in every clause field (district, offense,
+// original_sentence) — never a real value.
+const NA_SENTINEL = "N/A";
+
+/** Field-specific sentinels beyond "N/A" for the `offense` field. */
+export const OFFENSE_SENTINELS = new Set(["Download PDF Clemency Warrant"]);
+
+/**
+ * Preemptive-pardon scope legalese describes what the pardon covers — not a
+ * conviction or a sentence. It leaks into both the offense and
+ * original_sentence fields, and DOJ's phrasing varies: "For any offenses
+ * against the United States which he may have committed…" (Fauci, Milley,
+ * J6 Committee), "For any nonviolent offenses…" (Biden family), "For those
+ * offenses against the United States which he has committed or may have
+ * committed…" (Hunter Biden), "For those offenses she has or may have
+ * committed … related to election integrity…" (Tina Peters — no "against
+ * the United States" clause at all). The shared skeleton is
+ * `For any|those … offenses … committed`; anchoring on it instead of any
+ * one phrasing keeps the next variant from slipping through as a fake
+ * conviction. Test against quote-stripped text — DOJ wraps some values in
+ * curly quotes (Tina Peters).
+ */
+export const PARDON_SCOPE_LEGALESE =
+  /^for\s+(?:any|those)\b[\s\S]{0,120}?\boffenses\b[\s\S]{0,400}?\bcommitted\b/i;
+
+// Wrapping double quotes (straight or curly) around a whole clause value —
+// DOJ quotes some scope legalese verbatim. Stripped for display: the site
+// adds its own quoting when it renders warrant prose.
+const WRAPPING_QUOTES = /^["“”]\s*([\s\S]*?)\s*["“”]$/;
+
+/**
+ * DOJ HTML uses &nbsp; inside some recipient names and clause values (repo
+ * gotcha). Display strings must show regular spaces; slug/override lookups
+ * elsewhere must NOT use this (they are byte-exact).
+ */
+export function normalizeSpaces(s: string): string {
+  return s.replace(/\u00A0/g, " ");
+}
+
+/**
+ * Sentinel-free display text: NBSP→space, trim, null for empty/sentinel
+ * values. Keeps punctuation, keeps scope legalese (which is informative and
+ * self-describing on listing surfaces).
+ */
+export function displayClause(
+  value: string | null | undefined,
+  extraSentinels?: Set<string>,
+): string | null {
+  if (!value) return null;
+  const trimmed = normalizeSpaces(value).trim().replace(WRAPPING_QUOTES, "$1");
+  if (!trimmed || trimmed === NA_SENTINEL || extraSentinels?.has(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * `displayClause` minus the trailing period, so callers can add their own
+ * punctuation without doubling.
+ */
+export function cleanClause(
+  value: string | null | undefined,
+  extraSentinels?: Set<string>,
+): string | null {
+  return displayClause(value, extraSentinels)?.replace(/\.$/, "") ?? null;
+}
+
+/**
+ * A clause value that is real conviction content — not a sentinel, not scope
+ * legalese (which would falsely read as a conviction or a sentence). Trailing
+ * period stripped, for sentence composition.
+ */
+export function realClause(
+  value: string | null | undefined,
+  extraSentinels?: Set<string>,
+): string | null {
+  const cleaned = cleanClause(value, extraSentinels);
+  if (!cleaned || PARDON_SCOPE_LEGALESE.test(cleaned)) return null;
+  return cleaned;
+}
+
+/**
+ * Display-quality counterpart of `realClause`: real conviction content with
+ * punctuation kept. Same nullity as `realClause`.
+ */
+export function proseClause(
+  value: string | null | undefined,
+  extraSentinels?: Set<string>,
+): string | null {
+  const display = displayClause(value, extraSentinels);
+  if (!display || PARDON_SCOPE_LEGALESE.test(display)) return null;
+  return display;
+}
+
+/**
+ * The scope legalese itself, display-quality — or null when the value is a
+ * real offense/sentence or a sentinel. Used to render what a preemptive
+ * pardon covers, in the warrant's own words.
+ */
+export function scopeClause(value: string | null | undefined): string | null {
+  const display = displayClause(value);
+  if (!display || !PARDON_SCOPE_LEGALESE.test(display)) return null;
+  return display;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import {
     findHeadlineAction,
 } from "../lib/pardon-stats";
 import { getAdministrationIndex } from "../lib/president-names";
+import { displayClause, OFFENSE_SENTINELS } from "../lib/pardon-clause";
 import {
     formatCompactMoney,
     formatGrantDateLong,
@@ -238,6 +239,9 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                         const lastName = d.president_name.split(" ").slice(-1)[0];
                         const restitution = d.restitution ?? 0;
                         const typeLabel = d.clemency_type === "pardon" ? "Pardon" : "Commutation";
+                        // Sentinel-free display values (pardon-clause.ts)
+                        const offenseText = displayClause(d.offense, OFFENSE_SENTINELS);
+                        const districtText = displayClause(d.district);
                         return (
                             <a
                                 class="wire-item"
@@ -257,8 +261,8 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                                         <span class="wire-type">{typeLabel}</span>
                                     </div>
                                     <div class="wire-what">
-                                        {d.offense}
-                                        {d.district && ` · ${d.district}`}
+                                        {offenseText}
+                                        {districtText && ` · ${districtText}`}
                                     </div>
                                 </div>
                                 <div class="wire-pres">
@@ -370,6 +374,9 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                 {restitutionLeaderboard.map((entry, i) => {
                     const d = entry.data;
                     const adminDisplay = adminIndex.get(d.administration_slug)?.displayName ?? d.president_name;
+                    // Sentinel-free display values (pardon-clause.ts)
+                    const offenseText = displayClause(d.offense, OFFENSE_SENTINELS);
+                    const districtText = displayClause(d.district);
                     return (
                         <a
                             class="lb-row"
@@ -382,8 +389,8 @@ const heroEyebrow = `Presidential clemency · ${modernEraStartYear} → present`
                             <div>
                                 <div class="lb-name">{d.recipient_name}</div>
                                 <div class="lb-offense">
-                                    {d.offense}
-                                    {d.district && ` · ${d.district}`}
+                                    {offenseText}
+                                    {districtText && ` · ${districtText}`}
                                 </div>
                             </div>
                             <div class="lb-pres">

--- a/src/pages/pardon/details/[slug].astro
+++ b/src/pages/pardon/details/[slug].astro
@@ -6,6 +6,12 @@ import { getCollection } from "astro:content";
 import { resolveUrl } from "../../../lib/parsers/types";
 import { generateBreadcrumbJsonLd } from "../../../lib/seo";
 import { buildDetailSeo } from "../../../lib/detail-seo";
+import {
+    displayClause,
+    OFFENSE_SENTINELS,
+    proseClause,
+    scopeClause,
+} from "../../../lib/pardon-clause";
 import { getAdministrationIndex } from "../../../lib/president-names";
 import {
     formatCompactMoney,
@@ -98,8 +104,27 @@ const categoryLabel =
     categoryLabels[data.offense_category] ??
     data.offense_category.replace(/\b\w/g, (c) => c.toUpperCase());
 
-// Offenses — split the comma-joined `offense` field into a numbered list
-const offenses = data.offense
+// Conviction vs scope mode (CONTEXT.md, "Preemptive pardon"). A record is
+// conviction-shaped only when its offense field holds real conviction content
+// — not a scraper sentinel, not preemptive-pardon scope legalese. Same
+// predicate family the SEO layer uses, so page and SERP never disagree.
+const convictionOffense = proseClause(data.offense, OFFENSE_SENTINELS);
+const isConviction = convictionOffense !== null;
+
+// Scope prose for preemptive pardons — the warrant's own words. Usually in
+// the offense field; Hunter Biden's offense is the sentinel and his legalese
+// leaks into original_sentence instead, hence the fallback.
+const scopeText = scopeClause(data.offense) ?? scopeClause(data.original_sentence);
+
+// Sentinel-free district ("N/A" must never render) and original sentence
+// (legalese must never masquerade as a court sentence).
+const district = displayClause(data.district);
+const originalSentenceText = proseClause(data.original_sentence);
+
+// Offenses — split the comma-joined `offense` field into a numbered list.
+// Only meaningful in conviction mode; scope legalese contains commas that
+// are not count boundaries.
+const offenses = (convictionOffense ?? "")
     .split(",")
     .map((o) => o.trim())
     .filter((o) => o.length > 0);
@@ -121,7 +146,7 @@ const hasFine = data.fine != null && data.fine > 0;
 const hasNumericSentence =
     data.sentence_in_months != null && data.sentence_in_months > 0;
 const hasLifeSentence =
-    !hasNumericSentence && data.original_sentence?.toLowerCase().includes("life");
+    !hasNumericSentence && originalSentenceText?.toLowerCase().includes("life");
 
 if (hasRestitution) {
     stripBlocks.push({
@@ -154,7 +179,7 @@ if (hasNumericSentence) {
                 ? "Sentence commuted"
                 : "Sentence",
         value: formatSentenceCompact(data.sentence_in_months),
-        sub: data.original_sentence ?? undefined,
+        sub: originalSentenceText ?? undefined,
         accent: false,
         muted: false,
     });
@@ -165,7 +190,7 @@ if (hasNumericSentence) {
                 ? "Life sentence commuted"
                 : "Life sentence",
         value: "Life",
-        sub: data.original_sentence ?? undefined,
+        sub: originalSentenceText ?? undefined,
         accent: false,
         muted: false,
     });
@@ -185,7 +210,10 @@ const sources = [
     },
 ].filter((s) => s.url);
 
-// Aside metadata kv-rows — em-dash for null/undefined, "$0" preserved for zero
+// Aside metadata kv-rows — em-dash for null/undefined, "$0" preserved for zero.
+// Em-dash means "unknown" — reserved for conviction records with missing data.
+// In scope mode the district/sentencing values are inapplicable (there was no
+// case), so their rows and the whole Sentencing & impact block are omitted.
 type KvRow = { key: string; value: string; unknown?: boolean };
 const caseDetails: KvRow[] = [
     { key: "Clemency type", value: clemencyLabel },
@@ -193,9 +221,9 @@ const caseDetails: KvRow[] = [
     { key: "President", value: adminDisplay },
     { key: "Category", value: categoryLabel },
 ];
-if (data.district) {
-    caseDetails.push({ key: "District", value: data.district });
-} else {
+if (district) {
+    caseDetails.push({ key: "District", value: district });
+} else if (isConviction) {
     caseDetails.push({ key: "District", value: "—", unknown: true });
 }
 
@@ -262,8 +290,8 @@ const ogImagePath = `/og/${data.slug}.png`;
                 <span class="db-meta-by">{grantDateLong}</span>
             </div>
             <h1 class="db-name">{data.recipient_name}.</h1>
-            {data.district && (
-                <p class="db-district">{data.district}</p>
+            {district && (
+                <p class="db-district">{district}</p>
             )}
         </header>
 
@@ -316,31 +344,57 @@ const ogImagePath = `/og/${data.slug}.png`;
 
         <div class="db-grid">
             <div class="db-main">
-                <!-- Offenses -->
-                <section class="db-section">
-                    <div class="db-section-eyebrow">The conviction</div>
-                    <h2 class="db-section-title">
-                        {offenses.length === 1
-                            ? "One federal count."
-                            : `${offenses.length} federal counts.`}
-                    </h2>
-                    <div class="db-off-list">
-                        {offenses.map((offense, i) => (
-                            <div class="db-off-row">
-                                <div class="db-off-n">
-                                    {String(i + 1).padStart(2, "0")}
+                <!--
+                    Offenses (conviction mode) or pardon scope (scope mode).
+                    Preemptive pardons have no conviction: no counts, no
+                    "convicted of" framing — the warrant's scope prose renders
+                    as a single quoted block instead (CONTEXT.md, "Preemptive
+                    pardon").
+                -->
+                {isConviction ? (
+                    <section class="db-section">
+                        {/*
+                            Single lead-in, no eyebrow: "THE CONVICTION" +
+                            "The offense." double-labeled the same idea.
+                            "Convicted of:" flows straight into the list.
+                        */}
+                        <h2 class="db-section-title">Convicted of:</h2>
+                        <div class="db-off-list">
+                            {offenses.map((offense, i) => (
+                                <div class="db-off-row">
+                                    <div class="db-off-n">
+                                        {String(i + 1).padStart(2, "0")}
+                                    </div>
+                                    <div class="db-off-text">
+                                        {offense.charAt(0).toUpperCase() +
+                                            offense.slice(1)}
+                                    </div>
                                 </div>
-                                <div class="db-off-text">
-                                    {offense.charAt(0).toUpperCase() +
-                                        offense.slice(1)}
+                            ))}
+                        </div>
+                    </section>
+                ) : (
+                    scopeText && (
+                        <section class="db-section">
+                            <div class="db-section-eyebrow">
+                                The {clemencyLabel.toLowerCase()}
+                            </div>
+                            <h2 class="db-section-title">
+                                What this {clemencyLabel.toLowerCase()} covers.
+                            </h2>
+                            <div class="db-pull">
+                                <div class="db-pull-lbl">From the warrant</div>
+                                <p class="db-pull-text">{scopeText}</p>
+                                <div class="db-pull-src">
+                                    Signed by {adminDisplay} · {grantDateLong}
                                 </div>
                             </div>
-                        ))}
-                    </div>
-                </section>
+                        </section>
+                    )
+                )}
 
                 <!-- Original sentence pull-quote (preserved bold-mockup treatment) -->
-                {data.original_sentence && (
+                {originalSentenceText && (
                     <section class="db-section">
                         <div class="db-section-eyebrow">From the warrant</div>
                         <h2 class="db-section-title">
@@ -350,10 +404,10 @@ const ogImagePath = `/og/${data.slug}.png`;
                             <div class="db-pull-lbl">
                                 As recorded by the court
                             </div>
-                            <p class="db-pull-text">{data.original_sentence}</p>
-                            {data.district && (
+                            <p class="db-pull-text">{originalSentenceText}</p>
+                            {district && (
                                 <div class="db-pull-src">
-                                    {data.district} · DOJ warrant
+                                    {district} · DOJ warrant
                                 </div>
                             )}
                         </div>
@@ -381,24 +435,26 @@ const ogImagePath = `/og/${data.slug}.png`;
                     </div>
                 </div>
 
-                <div class="db-aside-block">
-                    <h4>Sentencing &amp; impact</h4>
-                    <div class="db-kv">
-                        {sentencingRows.map((row) => (
-                            <div class="db-kv-row">
-                                <div class="db-kv-k">{row.key}</div>
-                                <div
-                                    class:list={[
-                                        "db-kv-v",
-                                        row.unknown && "db-kv-unknown",
-                                    ]}
-                                >
-                                    {row.value}
+                {isConviction && (
+                    <div class="db-aside-block">
+                        <h4>Sentencing &amp; impact</h4>
+                        <div class="db-kv">
+                            {sentencingRows.map((row) => (
+                                <div class="db-kv-row">
+                                    <div class="db-kv-k">{row.key}</div>
+                                    <div
+                                        class:list={[
+                                            "db-kv-v",
+                                            row.unknown && "db-kv-unknown",
+                                        ]}
+                                    >
+                                        {row.value}
+                                    </div>
                                 </div>
-                            </div>
-                        ))}
+                            ))}
+                        </div>
                     </div>
-                </div>
+                )}
 
                 {sources.length > 0 && (
                     <div class="db-aside-block">

--- a/src/pages/recent.astro
+++ b/src/pages/recent.astro
@@ -8,6 +8,7 @@ import {
     getCurrentAdministration,
 } from "../lib/president-names";
 import { getCategoryColor } from "../lib/category-colors";
+import { displayClause, OFFENSE_SENTINELS } from "../lib/pardon-clause";
 import {
     formatCompactMoney,
     formatGrantDateLong,
@@ -204,6 +205,12 @@ function dayLabel(isoDate: string): string {
                                     d.clemency_type === "pardon"
                                         ? "Pardon"
                                         : "Commutation";
+                                // Sentinel-free display values (pardon-clause.ts)
+                                const offenseText = displayClause(
+                                    d.offense,
+                                    OFFENSE_SENTINELS,
+                                );
+                                const districtText = displayClause(d.district);
                                 return (
                                     <a
                                         class="rb-entry"
@@ -241,16 +248,16 @@ function dayLabel(isoDate: string): string {
                                                 >
                                                     {catLabel}
                                                 </span>
-                                                {d.offense && (
+                                                {offenseText && (
                                                     <span class="rb-offense">
                                                         {" · "}
-                                                        {d.offense}
+                                                        {offenseText}
                                                     </span>
                                                 )}
-                                                {d.district && (
+                                                {districtText && (
                                                     <span class="rb-district">
                                                         {" · "}
-                                                        {d.district}
+                                                        {districtText}
                                                     </span>
                                                 )}
                                             </div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -6,6 +6,7 @@ import '../styles/global.css';
 import { getCollection } from "astro:content";
 import { getAdministrationIndex } from "../lib/president-names";
 import { getCategoryColor } from "../lib/category-colors";
+import { displayClause, OFFENSE_SENTINELS, proseClause } from "../lib/pardon-clause";
 
 const currentPath = Astro.url.pathname;
 
@@ -49,9 +50,13 @@ const searchResults = sortedGrants.map((entry) => {
         name: d.recipient_name,
         clemencyType: d.clemency_type,
         category: d.offense_category,
-        offense: d.offense,
-        district: d.district ?? "",
-        sentence: formatSentence(d.sentence_in_months, d.original_sentence),
+        // Sentinel-free display values ("N/A" district, garbage offense) and a
+        // legalese-free sentence — a pardon's scope prose is not a court
+        // sentence (see pardon-clause.ts). Scope legalese stays visible in the
+        // offense column: it is informative and self-describing.
+        offense: displayClause(d.offense, OFFENSE_SENTINELS) ?? "",
+        district: displayClause(d.district) ?? "",
+        sentence: formatSentence(d.sentence_in_months, proseClause(d.original_sentence)),
         grantDate: d.grant_date,
         date: formatDate(d.grant_date),
         restitution: d.restitution ?? 0,


### PR DESCRIPTION
## Summary

A record is conviction-shaped only when its offense field holds real conviction content — not scraper sentinels, not the warrant's scope legalese. Six records (Fauci, Milley, Tina Peters, Hunter Biden, two group clemencies) rendered as fake convictions: "The conviction · 3 federal counts", literal "N/A" districts, "Offense: Download PDF Clemency Warrant" in the atom feed.

## Changes

- add `src/lib/pardon-clause.ts`: shared clause predicates (display/clean/real/prose/scope), one source of truth for every surface
- detail page: scope mode renders warrant prose as "What this pardon covers"; drops fake counts, District row, Sentencing & impact block
- conviction pages: single "Convicted of:" lead-in replaces the "THE CONVICTION" eyebrow + "N federal counts." pairing
- legalese detection anchors on the shared skeleton "For any|those … offenses … committed", quote-stripped (Tina Peters variant); validated against all 6,452 clause values — 6 matches, 0 false positives
- gate search/home/recent/atom-feed sentinel and legalese leaks
- docs: ADR-0006, ADR-0003 amendment, CONTEXT.md preemptive-pardon term + three-axes rule, CLAUDE.md gotcha